### PR TITLE
Multithreaded rendering in WaveSabrePlayerLib

### DIFF
--- a/Tests/PlayerTest/main.cpp
+++ b/Tests/PlayerTest/main.cpp
@@ -19,9 +19,11 @@ int main(int argc, char **argv)
 	bool writeWav = argc >= 2 && !strcmp(argv[1], "-w");
 	bool preRender = argc == 2 && !strcmp(argv[1], "-p");
 
+	const int numRenderThreads = 3;
+
 	if (writeWav)
 	{
-		WavWriter wavWriter(&Song);
+		WavWriter wavWriter(&Song, numRenderThreads);
 
 		printf("WAV writer activated.\n");
 
@@ -40,13 +42,13 @@ int main(int argc, char **argv)
 			printf("Prerender activated.\n");
 			printf("Rendering...\n");
 
-			player = new PreRenderPlayer(&Song, progressCallback, nullptr);
+			player = new PreRenderPlayer(&Song, numRenderThreads, progressCallback, nullptr);
 
 			printf("\n\n");
 		}
 		else
 		{
-			player = new RealtimePlayer(&Song);
+			player = new RealtimePlayer(&Song, numRenderThreads);
 		}
 
 		printf("Realtime player activated. Press ESC to quit.\n");

--- a/WaveSabrePlayerLib/WaveSabrePlayerLib.vcxproj
+++ b/WaveSabrePlayerLib/WaveSabrePlayerLib.vcxproj
@@ -12,6 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\WaveSabrePlayerLib.h" />
+    <ClInclude Include="include\WaveSabrePlayerLib\CriticalSection.h" />
     <ClInclude Include="include\WaveSabrePlayerLib\IPlayer.h" />
     <ClInclude Include="include\WaveSabrePlayerLib\RealtimePlayer.h" />
     <ClInclude Include="include\WaveSabrePlayerLib\DirectSoundRenderThread.h" />
@@ -20,6 +21,7 @@
     <ClInclude Include="include\WaveSabrePlayerLib\WavWriter.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="src\CriticalSection.cpp" />
     <ClCompile Include="src\IPlayer.cpp" />
     <ClCompile Include="src\RealtimePlayer.cpp" />
     <ClCompile Include="src\DirectSoundRenderThread.cpp" />

--- a/WaveSabrePlayerLib/WaveSabrePlayerLib.vcxproj.filters
+++ b/WaveSabrePlayerLib/WaveSabrePlayerLib.vcxproj.filters
@@ -25,6 +25,9 @@
     <ClInclude Include="include\WaveSabrePlayerLib\IPlayer.h">
       <Filter>WaveSabrePlayerLib</Filter>
     </ClInclude>
+    <ClInclude Include="include\WaveSabrePlayerLib\CriticalSection.h">
+      <Filter>WaveSabrePlayerLib</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\SongRenderer.cpp">
@@ -46,6 +49,9 @@
       <Filter>WaveSabrePlayerLib</Filter>
     </ClCompile>
     <ClCompile Include="src\IPlayer.cpp">
+      <Filter>WaveSabrePlayerLib</Filter>
+    </ClCompile>
+    <ClCompile Include="src\CriticalSection.cpp">
       <Filter>WaveSabrePlayerLib</Filter>
     </ClCompile>
   </ItemGroup>

--- a/WaveSabrePlayerLib/include/WaveSabrePlayerLib/CriticalSection.h
+++ b/WaveSabrePlayerLib/include/WaveSabrePlayerLib/CriticalSection.h
@@ -1,0 +1,31 @@
+#ifndef __WAVESABREPLAYERLIB_CRITICALSECTION__
+#define __WAVESABREPLAYERLIB_CRITICALSECTION__
+
+#include <Windows.h>
+
+namespace WaveSabrePlayerLib
+{
+	class CriticalSection
+	{
+	public:
+		class CriticalSectionGuard
+		{
+		public:
+			CriticalSectionGuard(CriticalSection *criticalSection);
+			~CriticalSectionGuard();
+
+		private:
+			CriticalSection *criticalSection;
+		};
+
+		CriticalSection();
+		~CriticalSection();
+
+		CriticalSectionGuard Enter();
+
+	private:
+		CRITICAL_SECTION criticalSection;
+	};
+}
+
+#endif

--- a/WaveSabrePlayerLib/include/WaveSabrePlayerLib/DirectSoundRenderThread.h
+++ b/WaveSabrePlayerLib/include/WaveSabrePlayerLib/DirectSoundRenderThread.h
@@ -2,6 +2,7 @@
 #define __WAVESABREPLAYERLIB_DIRECTSOUNDRENDERTHREAD_H__
 
 #include "SongRenderer.h"
+#include "CriticalSection.h"
 
 #include <Windows.h>
 #include <dsound.h>
@@ -25,7 +26,7 @@ namespace WaveSabrePlayerLib
 		int bufferSizeMs;
 
 		HANDLE thread;
-		CRITICAL_SECTION criticalSection;
+		CriticalSection criticalSection;
 		bool shutdown;
 	};
 }

--- a/WaveSabrePlayerLib/include/WaveSabrePlayerLib/PreRenderPlayer.h
+++ b/WaveSabrePlayerLib/include/WaveSabrePlayerLib/PreRenderPlayer.h
@@ -12,7 +12,7 @@ namespace WaveSabrePlayerLib
 	public:
 		typedef void (*ProgressCallback)(double progress, void *data);
 
-		PreRenderPlayer(const SongRenderer::Song *song, ProgressCallback callback, void *data, int playbackBufferSizeMs = 100);
+		PreRenderPlayer(const SongRenderer::Song *song, int numRenderThreads, ProgressCallback callback, void *data, int playbackBufferSizeMs = 100);
 		virtual ~PreRenderPlayer();
 
 		virtual void Play();

--- a/WaveSabrePlayerLib/include/WaveSabrePlayerLib/RealtimePlayer.h
+++ b/WaveSabrePlayerLib/include/WaveSabrePlayerLib/RealtimePlayer.h
@@ -10,7 +10,7 @@ namespace WaveSabrePlayerLib
 	class RealtimePlayer : public IPlayer
 	{
 	public:
-		RealtimePlayer(const SongRenderer::Song *song, int bufferSizeMs = 1000);
+		RealtimePlayer(const SongRenderer::Song *song, int numRenderThreads, int bufferSizeMs = 1000);
 		virtual ~RealtimePlayer();
 
 		virtual void Play();
@@ -24,6 +24,7 @@ namespace WaveSabrePlayerLib
 		static void renderCallback(SongRenderer::Sample *buffer, int numSamples, void *data);
 
 		const SongRenderer::Song *song;
+		int numRenderThreads;
 		int bufferSizeMs;
 
 		unsigned int startTime;

--- a/WaveSabrePlayerLib/include/WaveSabrePlayerLib/SongRenderer.h
+++ b/WaveSabrePlayerLib/include/WaveSabrePlayerLib/SongRenderer.h
@@ -76,6 +76,13 @@ namespace WaveSabrePlayerLib
 		class Track
 		{
 		public:
+			typedef struct
+			{
+				int SendingTrackIndex;
+				int ReceivingChannelIndex;
+				float Volume;
+			} Receive;
+
 			Track(SongRenderer *songRenderer, DeviceFactory factory);
 			~Track();
 			
@@ -85,15 +92,11 @@ namespace WaveSabrePlayerLib
 			static const int numBuffers = 4;
 		public:
 			float *Buffers[numBuffers];
+
+			int NumReceives;
+			Receive *Receives;
+
 		private:
-
-			typedef struct
-			{
-				int SendingTrackIndex;
-				int ReceivingChannelIndex;
-				float Volume;
-			} Receive;
-
 			class Automation
 			{
 			public:
@@ -122,9 +125,6 @@ namespace WaveSabrePlayerLib
 			SongRenderer *songRenderer;
 
 			float volume;
-
-			int numReceives;
-			Receive *receives;
 
 			int numDevices;
 			int *devicesIndicies;

--- a/WaveSabrePlayerLib/include/WaveSabrePlayerLib/SongRenderer.h
+++ b/WaveSabrePlayerLib/include/WaveSabrePlayerLib/SongRenderer.h
@@ -36,7 +36,7 @@ namespace WaveSabrePlayerLib
 
 		static const int NumChannels = 2;
 
-		SongRenderer(const SongRenderer::Song *song);
+		SongRenderer(const SongRenderer::Song *song, int numRenderThreads);
 		~SongRenderer();
 
 		void RenderSamples(Sample *buffer, int numSamples);
@@ -139,11 +139,20 @@ namespace WaveSabrePlayerLib
 			int eventIndex;
 		};
 
+		enum class TrackRenderState
+		{
+			Idle,
+			Rendering,
+			Finished,
+		};
+
 		// TODO: Templatize? Might actually be bigger..
 		unsigned char readByte();
 		int readInt();
 		float readFloat();
 		double readDouble();
+
+		static DWORD WINAPI renderThreadProc(LPVOID lpParameter);
 
 		const unsigned char *songBlobPtr;
 		int songDataIndex;
@@ -160,7 +169,14 @@ namespace WaveSabrePlayerLib
 
 		int numTracks;
 		Track **tracks;
+		TrackRenderState *trackRenderStates;
 
+		int numRenderThreads;
+		HANDLE *renderThreads;
+		CRITICAL_SECTION criticalSection;
+
+		bool renderThreadShutdown;
+		int renderThreadNumFloatSamples;
 	};
 }
 

--- a/WaveSabrePlayerLib/include/WaveSabrePlayerLib/SongRenderer.h
+++ b/WaveSabrePlayerLib/include/WaveSabrePlayerLib/SongRenderer.h
@@ -1,6 +1,8 @@
 #ifndef __WAVESABREPLAYERLIB_SONGRENDERER_H__
 #define __WAVESABREPLAYERLIB_SONGRENDERER_H__
 
+#include "CriticalSection.h"
+
 #include <WaveSabreCore.h>
 
 namespace WaveSabrePlayerLib
@@ -173,7 +175,7 @@ namespace WaveSabrePlayerLib
 
 		int numRenderThreads;
 		HANDLE *renderThreads;
-		CRITICAL_SECTION criticalSection;
+		CriticalSection criticalSection;
 
 		bool renderThreadShutdown;
 		int renderThreadNumFloatSamples;

--- a/WaveSabrePlayerLib/include/WaveSabrePlayerLib/SongRenderer.h
+++ b/WaveSabrePlayerLib/include/WaveSabrePlayerLib/SongRenderer.h
@@ -141,20 +141,28 @@ namespace WaveSabrePlayerLib
 			int eventIndex;
 		};
 
-		enum class TrackRenderState
+		enum class TrackRenderState : unsigned int
 		{
 			Idle,
 			Rendering,
 			Finished,
 		};
 
+		typedef struct
+		{
+			SongRenderer *songRenderer;
+			int renderThreadIndex;
+		} RenderThreadData;
+
+		static DWORD WINAPI renderThreadProc(LPVOID lpParameter);
+
+		bool renderThreadWork(int renderThreadIndex);
+
 		// TODO: Templatize? Might actually be bigger..
 		unsigned char readByte();
 		int readInt();
 		float readFloat();
 		double readDouble();
-
-		static DWORD WINAPI renderThreadProc(LPVOID lpParameter);
 
 		const unsigned char *songBlobPtr;
 		int songDataIndex;
@@ -174,11 +182,13 @@ namespace WaveSabrePlayerLib
 		TrackRenderState *trackRenderStates;
 
 		int numRenderThreads;
-		HANDLE *renderThreads;
-		CriticalSection criticalSection;
+		HANDLE *additionalRenderThreads;
 
 		bool renderThreadShutdown;
 		int renderThreadNumFloatSamples;
+		unsigned int renderThreadsRunning;
+		HANDLE *renderThreadStartEvents;
+		HANDLE renderDoneEvent;
 	};
 }
 

--- a/WaveSabrePlayerLib/include/WaveSabrePlayerLib/WavWriter.h
+++ b/WaveSabrePlayerLib/include/WaveSabrePlayerLib/WavWriter.h
@@ -12,7 +12,7 @@ namespace WaveSabrePlayerLib
 	public:
 		typedef void (*ProgressCallback)(double progress, void *data);
 
-		WavWriter(const SongRenderer::Song *song);
+		WavWriter(const SongRenderer::Song *song, int numRenderThreads);
 		~WavWriter();
 
 		void Write(const char *fileName, ProgressCallback callback, void *data);

--- a/WaveSabrePlayerLib/src/CriticalSection.cpp
+++ b/WaveSabrePlayerLib/src/CriticalSection.cpp
@@ -1,0 +1,30 @@
+#include <WaveSabrePlayerLib\CriticalSection.h>
+
+namespace WaveSabrePlayerLib
+{
+	CriticalSection::CriticalSectionGuard::CriticalSectionGuard(CriticalSection *criticalSection)
+		: criticalSection(criticalSection)
+	{
+		EnterCriticalSection(&criticalSection->criticalSection);
+	}
+
+	CriticalSection::CriticalSectionGuard::~CriticalSectionGuard()
+	{
+		LeaveCriticalSection(&criticalSection->criticalSection);
+	}
+
+	CriticalSection::CriticalSection()
+	{
+		InitializeCriticalSection(&criticalSection);
+	}
+
+	CriticalSection::~CriticalSection()
+	{
+		DeleteCriticalSection(&criticalSection);
+	}
+
+	CriticalSection::CriticalSectionGuard CriticalSection::Enter()
+	{
+		return CriticalSectionGuard(this);
+	}
+}

--- a/WaveSabrePlayerLib/src/PreRenderPlayer.cpp
+++ b/WaveSabrePlayerLib/src/PreRenderPlayer.cpp
@@ -2,9 +2,9 @@
 
 namespace WaveSabrePlayerLib
 {
-	PreRenderPlayer::PreRenderPlayer(const SongRenderer::Song *song, ProgressCallback callback, void *data, int playbackBufferSizeMs)
+	PreRenderPlayer::PreRenderPlayer(const SongRenderer::Song *song, int numRenderThreads, ProgressCallback callback, void *data, int playbackBufferSizeMs)
 	{
-		SongRenderer songRenderer(song);
+		SongRenderer songRenderer(song, numRenderThreads);
 
 		tempo = songRenderer.GetTempo();
 		sampleRate = songRenderer.GetSampleRate();

--- a/WaveSabrePlayerLib/src/RealtimePlayer.cpp
+++ b/WaveSabrePlayerLib/src/RealtimePlayer.cpp
@@ -2,10 +2,11 @@
 
 namespace WaveSabrePlayerLib
 {
-	RealtimePlayer::RealtimePlayer(const SongRenderer::Song *song, int bufferSizeMs)
+	RealtimePlayer::RealtimePlayer(const SongRenderer::Song *song, int numRenderThreads, int bufferSizeMs)
 		: song(song)
+		, numRenderThreads(numRenderThreads)
 		, bufferSizeMs(bufferSizeMs)
-		, songRenderer(new SongRenderer(song))
+		, songRenderer(new SongRenderer(song, numRenderThreads))
 		, renderThread(nullptr)
 	{
 	}
@@ -25,7 +26,7 @@ namespace WaveSabrePlayerLib
 		if (songRenderer)
 			delete songRenderer;
 
-		songRenderer = new SongRenderer(song);
+		songRenderer = new SongRenderer(song, numRenderThreads);
 		renderThread = new DirectSoundRenderThread(renderCallback, this, songRenderer->GetSampleRate(), bufferSizeMs);
 
 		startTime = timeGetTime();

--- a/WaveSabrePlayerLib/src/SongRenderer.Track.cpp
+++ b/WaveSabrePlayerLib/src/SongRenderer.Track.cpp
@@ -12,15 +12,15 @@ namespace WaveSabrePlayerLib
 
 		volume = songRenderer->readFloat();
 
-		numReceives = songRenderer->readInt();
-		if (numReceives)
+		NumReceives = songRenderer->readInt();
+		if (NumReceives)
 		{
-			receives = new Receive[numReceives];
-			for (int i = 0; i < numReceives; i++)
+			Receives = new Receive[NumReceives];
+			for (int i = 0; i < NumReceives; i++)
 			{
-				receives[i].SendingTrackIndex = songRenderer->readInt();
-				receives[i].ReceivingChannelIndex = songRenderer->readInt();
-				receives[i].Volume = songRenderer->readFloat();
+				Receives[i].SendingTrackIndex = songRenderer->readInt();
+				Receives[i].ReceivingChannelIndex = songRenderer->readInt();
+				Receives[i].Volume = songRenderer->readFloat();
 			}
 		}
 
@@ -55,7 +55,9 @@ namespace WaveSabrePlayerLib
 	SongRenderer::Track::~Track()
 	{
 		for (int i = 0; i < numBuffers; i++) delete [] Buffers[i];
-		if (numReceives) delete [] receives;
+
+		if (NumReceives)
+			delete [] Receives;
 		
 		if (numDevices)
 		{
@@ -93,9 +95,9 @@ namespace WaveSabrePlayerLib
 		for (int i = 0; i < numAutomations; i++) automations[i]->Run(numSamples);
 
 		for (int i = 0; i < numBuffers; i++) memset(Buffers[i], 0, numSamples * sizeof(float));
-		for (int i = 0; i < numReceives; i++)
+		for (int i = 0; i < NumReceives; i++)
 		{
-			Receive *r = &receives[i];
+			Receive *r = &Receives[i];
 			float **receiveBuffers = songRenderer->tracks[r->SendingTrackIndex]->Buffers;
 			for (int j = 0; j < 2; j++)
 			{

--- a/WaveSabrePlayerLib/src/WavWriter.cpp
+++ b/WaveSabrePlayerLib/src/WavWriter.cpp
@@ -4,9 +4,9 @@
 
 namespace WaveSabrePlayerLib
 {
-	WavWriter::WavWriter(const SongRenderer::Song *song)
+	WavWriter::WavWriter(const SongRenderer::Song *song, int numRenderThreads)
 	{
-		songRenderer = new SongRenderer(song);
+		songRenderer = new SongRenderer(song, numRenderThreads);
 	}
 
 	WavWriter::~WavWriter()

--- a/WaveSabrePlayerLib/src/WavWriter.cpp
+++ b/WaveSabrePlayerLib/src/WavWriter.cpp
@@ -66,6 +66,9 @@ namespace WaveSabrePlayerLib
 		}
 
 		fclose(file);
+
+		if (callback)
+			callback(1.0, data);
 	}
 
 	void WavWriter::writeInt(int i, FILE *file)

--- a/WaveSabreStandAlonePlayer/main.cpp
+++ b/WaveSabreStandAlonePlayer/main.cpp
@@ -39,6 +39,8 @@ int main(int argc, char **argv)
 	bool writeWav = argc >= 3 && !strcmp(argv[2], "-w");
 	bool preRender = argc == 3 && !strcmp(argv[2], "-p");
 
+	const int numRenderThreads = 3;
+
 	FILE * pFile;
 	long lSize;
 	unsigned char * buffer;
@@ -68,7 +70,7 @@ int main(int argc, char **argv)
 
 	if (writeWav)
 	{
-		WavWriter wavWriter(&song);
+		WavWriter wavWriter(&song, numRenderThreads);
 
 		printf("WAV writer activated.\n");
 
@@ -87,13 +89,13 @@ int main(int argc, char **argv)
 			printf("Prerender activated.\n");
 			printf("Rendering...\n");
 
-			player = new PreRenderPlayer(&song, progressCallback, nullptr);
+			player = new PreRenderPlayer(&song, numRenderThreads, progressCallback, nullptr);
 
 			printf("\n\n");
 		}
 		else
 		{
-			player = new RealtimePlayer(&song);
+			player = new RealtimePlayer(&song, numRenderThreads);
 		}
 
 		printf("Realtime player activated. Press ESC to quit.\n");


### PR DESCRIPTION
Since track rendering is inherently parallelizable, let's take advantage of this by dispatching track rendering to one or more worker threads instead of always rendering them in serial.

The result is typically a **40% improvement in rendering speed** going from 1-2 cores, with an additional few percent going to 3 or 4 cores (sometimes **up to nearly 60%**!).

Some concrete measurements for rendering entire songs:

![improvements](https://user-images.githubusercontent.com/3166056/53288453-6c166e00-3788-11e9-8e75-3c37242626a5.png)

And a bit more visual representation of the rendering being handled by a single core vs several cores:

![trashpanda-single](https://user-images.githubusercontent.com/3166056/53288481-c6afca00-3788-11e9-98b0-ec6d929916eb.PNG)

![trashpanda-multi3](https://user-images.githubusercontent.com/3166056/53288482-c9122400-3788-11e9-8270-e3b8ac0d020a.PNG)

As expected, we see a slight drop in performance for the single-core case due to the additional overhead, but it's not significant. I don't suspect any user would prefer to use that anyways and we shouldn't have to provide an alternative implementation just for that case; users can always fork the player code and do this themselves if this is absolutely necessary (which is in the git history, and this PR can also serve as a guide to remove it).

Implementation-wise, this only really involves managing a user-defined number of worker threads (3 is used in examples here) and some small administration code, which has been designed to be as lightweight as possible and especially not allocate any memory dynamically. All player types (`RealtimePlayer`, `PreRenderPlayer`, and `WavWriter`) take advantage of this, so even if a user has to pre-render a song (which we offer an option for in our intros), it should still be faster to do so (and possible to allocate different thread counts to that if desired). Note that I would certainly not mind getting some more eyes on this code as I _did_ have some issues getting it to work initially, but I think I've isolated and fixed all of the problems (both here and in isolated minimal reproductions) and this appears to be quite robust now.

To compare size with the new approach, I've packed [trashpanda](http://www.pouet.net/prod.php?which=78634) with the single-core approach we had before (effectively matching the public release) and with 3 audio rendering cores. The multi-core executable is **188 bytes larger** (60756 bytes before padding, vs 60568 bytes before padding). Admittedly that's somewhat larger than I expected, but still not very significant in terms of a 64k, and more than pays for itself with such a massive performance increase. If you'd like to test this build yourself, I've made it available [here](https://www.dropbox.com/s/eg4bz9aruj3gntc/logicoma-trashpanda-party-multi3.exe?dl=0).

This PR also introduces some additional small cleanups/fixes (see commits for details). One such cleanup is the introduction of the `CriticalSection` class which should be a bit easier to use than the win32 API directly, as well as making it easier to implement platform-specific versions of this in the future.