### PR TITLE
WaveSabreCore: use floorf instead of floor for floats

### DIFF
--- a/WaveSabreCore/src/ResampleBuffer.cpp
+++ b/WaveSabreCore/src/ResampleBuffer.cpp
@@ -49,7 +49,7 @@ namespace WaveSabreCore
 	float ResampleBuffer::ReadPosition(float position) const
 	{
 		int samplePos = (currentPosition + (int)position) % length; // actual sample position determined
-		float fraction = position - floor(position);  // fractional
+		float fraction = position - floorf(position);  // fractional
 		
 		float s0 = buffer[samplePos];
 		float s1 = (samplePos > 0) ? buffer[samplePos - 1] : buffer[length - 1];


### PR DESCRIPTION
This avoids a compile-time warning.