### PR TITLE
Plain arrays

### DIFF
--- a/WaveSabreCore/include/WaveSabreCore/Chamber.h
+++ b/WaveSabreCore/include/WaveSabreCore/Chamber.h
@@ -43,9 +43,9 @@ namespace WaveSabreCore
 		float dryWet;
 		float preDelay;
 
-		DelayBuffer **delayBuffers;
+		DelayBuffer *delayBuffers[numBuffers];
 
-		DelayBuffer *preDelayBuffers;
+		DelayBuffer preDelayBuffers[2];
 
 		StateVariableFilter lowCutFilter[2], highCutFilter[2];
 	};

--- a/WaveSabreCore/include/WaveSabreCore/SynthDevice.h
+++ b/WaveSabreCore/include/WaveSabreCore/SynthDevice.h
@@ -67,9 +67,9 @@ namespace WaveSabreCore
 
 		void clearEvents();
 
-		Voice **voices;
+		Voice *voices[maxVoices];
 
-		Event *events;
+		Event events[maxEvents];
 	};
 }
 

--- a/WaveSabreCore/src/Chamber.cpp
+++ b/WaveSabreCore/src/Chamber.cpp
@@ -13,10 +13,7 @@ namespace WaveSabreCore
 		dryWet = .27f;
 		preDelay = 0.0f;
 
-		delayBuffers = new DelayBuffer*[numBuffers];
 		for (int i = 0; i < numBuffers; i++) delayBuffers[i] = new DelayBuffer();
-
-		preDelayBuffers = new DelayBuffer[2];
 
 		for (int i = 0; i < 2; i++)
 		{
@@ -28,9 +25,6 @@ namespace WaveSabreCore
 	Chamber::~Chamber()
 	{
 		for (int i = 0; i < numBuffers; i++) delete delayBuffers[i];
-		delete [] delayBuffers;
-
-		delete[] preDelayBuffers;
 	}
 
 	void Chamber::Run(double songPosition, float **inputs, float **outputs, int numSamples)

--- a/WaveSabreCore/src/SynthDevice.cpp
+++ b/WaveSabreCore/src/SynthDevice.cpp
@@ -18,16 +18,12 @@ namespace WaveSabreCore
 
 		Rise = 0.0f;
 
-		voices = new Voice *[maxVoices];
-		events = new Event[maxEvents];
 		clearEvents();
 	}
 
 	SynthDevice::~SynthDevice()
 	{
 		for (int i = 0; i < maxVoices; i++) delete voices[i];
-		delete [] voices;
-		delete [] events;
 	}
 
 	void SynthDevice::Run(double songPosition, float **inputs, float **outputs, int numSamples)

--- a/WaveSabrePlayerLib/include/WaveSabrePlayerLib/SongRenderer.h
+++ b/WaveSabrePlayerLib/include/WaveSabrePlayerLib/SongRenderer.h
@@ -81,10 +81,11 @@ namespace WaveSabrePlayerLib
 			
 			void Run(int numSamples);
 
-			float **Buffers;
-
 		private:
 			static const int numBuffers = 4;
+		public:
+			float *Buffers[numBuffers];
+		private:
 
 			typedef struct
 			{

--- a/WaveSabrePlayerLib/src/SongRenderer.Track.cpp
+++ b/WaveSabrePlayerLib/src/SongRenderer.Track.cpp
@@ -6,7 +6,6 @@ namespace WaveSabrePlayerLib
 {
 	SongRenderer::Track::Track(SongRenderer *songRenderer, SongRenderer::DeviceFactory factory)
 	{
-		Buffers = new float *[numBuffers];
 		for (int i = 0; i < numBuffers; i++) Buffers[i] = new float[songRenderer->sampleRate];
 
 		this->songRenderer = songRenderer;
@@ -56,7 +55,6 @@ namespace WaveSabrePlayerLib
 	SongRenderer::Track::~Track()
 	{
 		for (int i = 0; i < numBuffers; i++) delete [] Buffers[i];
-		delete [] Buffers;
 		if (numReceives) delete [] receives;
 		
 		if (numDevices)


### PR DESCRIPTION
Here's a PR that inlines a few arrays from separate heap allocations into the parent objects. This should be a net win, as we do less work, and we always need this memory anyway.