### PR TITLE
Add USE_LIBPNG flag to WaveSabreVstLib build

### DIFF
--- a/WaveSabreVstLib/CMakeLists.txt
+++ b/WaveSabreVstLib/CMakeLists.txt
@@ -51,6 +51,8 @@ target_include_directories(WaveSabreVstLib PUBLIC
 	../Vst3.x/public.sdk/source/vst2.x
 	../Vst3.x)
 
+target_compile_definitions(WaveSabreVstLib PUBLIC USE_LIBPNG)
+
 if(MSVC)
 	target_compile_definitions(WaveSabreVstLib PUBLIC _CRT_SECURE_NO_WARNINGS)
 	target_compile_options(WaveSabreVstLib PUBLIC /EHsc)


### PR DESCRIPTION
This should have been in place as part of the cmake build commit(s), but we somehow missed it during testing. Required to load the .png assets in the plugs as png's and not as raw bitmaps.