### PR TITLE
envelope patch for short notes

### DIFF
--- a/WaveSabreCore/src/Envelope.cpp
+++ b/WaveSabreCore/src/Envelope.cpp
@@ -73,7 +73,7 @@ namespace WaveSabreCore
 
 		case EnvelopeState::Decay:
 			pos += posDelta;
-			if (pos >= Decay) State = EnvelopeState::Sustain;
+			if (pos >= Decay) State = Sustain > 0.0f ? EnvelopeState::Sustain : EnvelopeState::Finished;
 			break;
 
 		case EnvelopeState::Release:


### PR DESCRIPTION
while playing with one of the synths, I noticed that playing short envelopes (sustain = 0) when the sound stops, the notes are still running.
for example, if you play a short pluck sound with no sustain volume but with long notes, it's still rendering all the voices even though no sound is generated.

this patch essentially sayz, if our sustain is 0.0 then when we've reached the end of the decay, we can skip to finished as release will have no affect.

double checked this with sustain of zero but slower decay and longer release and this causes the decay to be skipped early and move straight onto release on note off.