### PR TITLE
live 10 support

### DIFF
--- a/WaveSabreConvert/LiveConverter.cs
+++ b/WaveSabreConvert/LiveConverter.cs
@@ -26,7 +26,6 @@ namespace WaveSabreConvert
         class Event
         {
             public double Time;
-            public int Samples;
             public Song.EventType Type;
             public byte Note;
             public byte Velocity;
@@ -58,7 +57,7 @@ namespace WaveSabreConvert
             }
 
             project.MasterTrack.Name = project.MasterTrack.Name == "" ? "Master" : project.MasterTrack.Name;
-
+            
             visitedTracks = new List<LiveProject.Track>();
             orderedTracks = new List<LiveProject.Track>();
 
@@ -81,7 +80,7 @@ namespace WaveSabreConvert
                     Song.Device device = null;
 
                     Song.DeviceId deviceId;
-                    if (Enum.TryParse<Song.DeviceId>(projectDevice.PluginDll.Replace(".dll", "").Replace(".64", ""), out deviceId))
+                    if (Enum.TryParse<Song.DeviceId>(projectDevice.PluginDll.Replace(".dll", "").Replace(".64",""), out deviceId))
                     {
                         device = new Song.Device();
                         device.Id = deviceId;
@@ -151,7 +150,6 @@ namespace WaveSabreConvert
                                             {
                                                 var startEvent = new Event();
                                                 startEvent.Time = startTime;
-                                                startEvent.Samples = secondsToSamples(startTime, song.Tempo, song.SampleRate);
                                                 startEvent.Type = Song.EventType.NoteOn;
                                                 startEvent.Note = (byte)keyTrack.MidiKey;
                                                 startEvent.Velocity = (byte)note.Velocity;
@@ -159,7 +157,6 @@ namespace WaveSabreConvert
 
                                                 var endEvent = new Event();
                                                 endEvent.Time = endTime;
-                                                endEvent.Samples = secondsToSamples(endTime, song.Tempo, song.SampleRate);
                                                 endEvent.Type = Song.EventType.NoteOff;
                                                 endEvent.Note = (byte)keyTrack.MidiKey;
                                                 events.Add(endEvent);
@@ -172,17 +169,17 @@ namespace WaveSabreConvert
                     }
                 }
                 events.Sort((a, b) =>
-                {
-                    if (a.Samples > b.Samples) return 1;
-                    if (a.Samples < b.Samples) return -1;
-                    if (a.Type == Song.EventType.NoteOn && b.Type == Song.EventType.NoteOff) return 1;
-                    if (a.Type == Song.EventType.NoteOff && b.Type == Song.EventType.NoteOn) return -1;
-                    return 0;
-                });
+                    {
+                        if (a.Time > b.Time) return 1;
+                        if (a.Time < b.Time) return -1;
+                        if (a.Type == Song.EventType.NoteOn && b.Type == Song.EventType.NoteOff) return 1;
+                        if (a.Type == Song.EventType.NoteOff && b.Type == Song.EventType.NoteOn) return -1;
+                        return 0;
+                    });
                 foreach (var e in events)
                 {
-                    if (!minEventTime.HasValue || e.Samples < minEventTime.Value) minEventTime = e.Samples;
-                    if (!maxEventTime.HasValue || e.Samples > maxEventTime.Value) maxEventTime = e.Samples;
+                    if (!minEventTime.HasValue || e.Time < minEventTime.Value) minEventTime = e.Time;
+                    if (!maxEventTime.HasValue || e.Time > maxEventTime.Value) maxEventTime = e.Time;
                 }
 
                 projectTracksToSongTracks.Add(projectTrack, track);
@@ -219,7 +216,7 @@ namespace WaveSabreConvert
                     var time = e.Time - songStartTime;
                     int timeStamp = Math.Max(secondsToSamples(time, (double)song.Tempo, (double)song.SampleRate), lastTimeStamp);
 
-                    songEvent.TimeStamp = e.Samples;
+                    songEvent.TimeStamp = secondsToSamples(time, (double) song.Tempo, (double) song.SampleRate);
                     songEvent.Type = e.Type;
                     songEvent.Note = e.Note;
                     songEvent.Velocity = e.Velocity;

--- a/WaveSabreConvert/LiveConverter.cs
+++ b/WaveSabreConvert/LiveConverter.cs
@@ -26,6 +26,7 @@ namespace WaveSabreConvert
         class Event
         {
             public double Time;
+            public int Samples;
             public Song.EventType Type;
             public byte Note;
             public byte Velocity;
@@ -57,7 +58,7 @@ namespace WaveSabreConvert
             }
 
             project.MasterTrack.Name = project.MasterTrack.Name == "" ? "Master" : project.MasterTrack.Name;
-            
+
             visitedTracks = new List<LiveProject.Track>();
             orderedTracks = new List<LiveProject.Track>();
 
@@ -80,7 +81,7 @@ namespace WaveSabreConvert
                     Song.Device device = null;
 
                     Song.DeviceId deviceId;
-                    if (Enum.TryParse<Song.DeviceId>(projectDevice.PluginDll.Replace(".dll", "").Replace(".64",""), out deviceId))
+                    if (Enum.TryParse<Song.DeviceId>(projectDevice.PluginDll.Replace(".dll", "").Replace(".64", ""), out deviceId))
                     {
                         device = new Song.Device();
                         device.Id = deviceId;
@@ -150,6 +151,7 @@ namespace WaveSabreConvert
                                             {
                                                 var startEvent = new Event();
                                                 startEvent.Time = startTime;
+                                                startEvent.Samples = secondsToSamples(startTime, song.Tempo, song.SampleRate);
                                                 startEvent.Type = Song.EventType.NoteOn;
                                                 startEvent.Note = (byte)keyTrack.MidiKey;
                                                 startEvent.Velocity = (byte)note.Velocity;
@@ -157,6 +159,7 @@ namespace WaveSabreConvert
 
                                                 var endEvent = new Event();
                                                 endEvent.Time = endTime;
+                                                endEvent.Samples = secondsToSamples(endTime, song.Tempo, song.SampleRate);
                                                 endEvent.Type = Song.EventType.NoteOff;
                                                 endEvent.Note = (byte)keyTrack.MidiKey;
                                                 events.Add(endEvent);
@@ -169,17 +172,17 @@ namespace WaveSabreConvert
                     }
                 }
                 events.Sort((a, b) =>
-                    {
-                        if (a.Time > b.Time) return 1;
-                        if (a.Time < b.Time) return -1;
-                        if (a.Type == Song.EventType.NoteOn && b.Type == Song.EventType.NoteOff) return 1;
-                        if (a.Type == Song.EventType.NoteOff && b.Type == Song.EventType.NoteOn) return -1;
-                        return 0;
-                    });
+                {
+                    if (a.Samples > b.Samples) return 1;
+                    if (a.Samples < b.Samples) return -1;
+                    if (a.Type == Song.EventType.NoteOn && b.Type == Song.EventType.NoteOff) return 1;
+                    if (a.Type == Song.EventType.NoteOff && b.Type == Song.EventType.NoteOn) return -1;
+                    return 0;
+                });
                 foreach (var e in events)
                 {
-                    if (!minEventTime.HasValue || e.Time < minEventTime.Value) minEventTime = e.Time;
-                    if (!maxEventTime.HasValue || e.Time > maxEventTime.Value) maxEventTime = e.Time;
+                    if (!minEventTime.HasValue || e.Samples < minEventTime.Value) minEventTime = e.Samples;
+                    if (!maxEventTime.HasValue || e.Samples > maxEventTime.Value) maxEventTime = e.Samples;
                 }
 
                 projectTracksToSongTracks.Add(projectTrack, track);
@@ -216,7 +219,7 @@ namespace WaveSabreConvert
                     var time = e.Time - songStartTime;
                     int timeStamp = Math.Max(secondsToSamples(time, (double)song.Tempo, (double)song.SampleRate), lastTimeStamp);
 
-                    songEvent.TimeStamp = secondsToSamples(time, (double) song.Tempo, (double) song.SampleRate);
+                    songEvent.TimeStamp = e.Samples;
                     songEvent.Type = e.Type;
                     songEvent.Note = e.Note;
                     songEvent.Velocity = e.Velocity;

--- a/WaveSabreConvert/LiveParser.cs
+++ b/WaveSabreConvert/LiveParser.cs
@@ -200,10 +200,11 @@ namespace WaveSabreConvert
 
         void parseTrack(bool isMasterTrack = false, bool isReturnTrack = false)
         {
+            var currentNode = reader.Name;
             var track = new LiveProject.Track();
             returnSendInfos.Add(track, new List<ReturnSendInfo>());
             if (!isMasterTrack) track.Id = getAttrib("Id");
-            while (reader.Read() && !(reader.NodeType == XmlNodeType.EndElement && (reader.Name == "MasterTrack" || reader.Name == "MidiTrack" || reader.Name == "AudioTrack" || reader.Name == "ReturnTrack" || reader.Name == "GroupTrack")))
+            while (reader.Read() && !(reader.NodeType == XmlNodeType.EndElement && reader.Name == currentNode))
             {
                 if (reader.NodeType == XmlNodeType.Element)
                 {
@@ -223,6 +224,9 @@ namespace WaveSabreConvert
                             break;
                         case "TrackGroupId":
                             track.TrackGroupId = getValueAttrib();
+                            break;
+                        case "AutomationEnvelopes":
+                            parseAutomationEnvelopes(track);
                             break;
                     }
                 }
@@ -250,7 +254,8 @@ namespace WaveSabreConvert
 
         void parseDeviceChain(LiveProject.Track track, bool isMasterTrack)
         {
-            while (reader.Read() && !(reader.NodeType == XmlNodeType.EndElement && (reader.Name == "DeviceChain" || reader.Name == "MasterChain")))
+            var currentNode = reader.Name;
+            while (reader.Read() && !(reader.NodeType == XmlNodeType.EndElement && reader.Name == currentNode))
             {
                 if (reader.NodeType == XmlNodeType.Element)
                 {
@@ -296,7 +301,7 @@ namespace WaveSabreConvert
                     {
                         case "PluginDevice":
                             var device = new LiveProject.Device();
-                            if (!reader.IsEmptyElement) parsePluginDevice(device);
+                            if (!reader.IsEmptyElement) parsePluginDevice(device, track);
                             track.Devices.Add(device);
                             break;
                     }
@@ -306,7 +311,8 @@ namespace WaveSabreConvert
 
         void parseMixer(LiveProject.Track track, bool isMasterTrack)
         {
-            while (reader.Read() && !(reader.NodeType == XmlNodeType.EndElement && reader.Name == "Mixer"))
+            var currentNode = reader.Name;
+            while (reader.Read() && !(reader.NodeType == XmlNodeType.EndElement && reader.Name == currentNode))
             {
                 if (reader.NodeType == XmlNodeType.Element)
                 {
@@ -319,7 +325,7 @@ namespace WaveSabreConvert
                         case "Speaker":
                             while (reader.Read())
                             {
-                                if (reader.NodeType == XmlNodeType.Element && reader.Name == "BoolEvent")
+                                if (reader.NodeType == XmlNodeType.Element && (reader.Name == "BoolEvent" || reader.Name == "Manual"))
                                 {
                                     track.IsSpeakerOn = getBoolValueAttrib();
                                     break;
@@ -330,7 +336,7 @@ namespace WaveSabreConvert
                         case "Volume":
                             while (reader.Read())
                             {
-                                if (reader.NodeType == XmlNodeType.Element && reader.Name == "FloatEvent")
+                                if (reader.NodeType == XmlNodeType.Element && (reader.Name == "FloatEvent" || reader.Name == "Manual"))
                                 {
                                     track.Volume = getDoubleValueAttrib();
                                     break;
@@ -343,7 +349,7 @@ namespace WaveSabreConvert
                             {
                                 while (reader.Read())
                                 {
-                                    if (reader.NodeType == XmlNodeType.Element && reader.Name == "FloatEvent")
+                                    if (reader.NodeType == XmlNodeType.Element && (reader.Name == "FloatEvent" || reader.Name == "Manual"))
                                     {
                                         project.Tempo = getDoubleValueAttrib();
                                         break;
@@ -531,7 +537,7 @@ namespace WaveSabreConvert
             midiClip.KeyTracks.Add(keyTrack);
         }
 
-        void parsePluginDevice(LiveProject.Device device)
+        void parsePluginDevice(LiveProject.Device device, LiveProject.Track track)
         {
             device.Id = getAttrib("Id");
             while (reader.Read() && !(reader.NodeType == XmlNodeType.EndElement && reader.Name == "PluginDevice"))
@@ -543,7 +549,7 @@ namespace WaveSabreConvert
                         case "On":
                             while (reader.Read())
                             {
-                                if (reader.NodeType == XmlNodeType.Element && reader.Name == "BoolEvent")
+                                if (reader.NodeType == XmlNodeType.Element && (reader.Name == "BoolEvent" || reader.Name == "Manual"))
                                 {
                                     device.Bypass = !getBoolValueAttrib();
                                     break;
@@ -556,7 +562,7 @@ namespace WaveSabreConvert
                             break;
 
                         case "ParameterList":
-                            if (!reader.IsEmptyElement) parseParameterList(device);
+                            if (!reader.IsEmptyElement) parseParameterList(device, track);
                             break;
                     }
                 }
@@ -585,7 +591,8 @@ namespace WaveSabreConvert
 
         void parseVstPreset(LiveProject.Device device)
         {
-            while (reader.Read() && !(reader.NodeType == XmlNodeType.EndElement && reader.Name == "VstPreset"))
+            var currentNode = reader.Name;
+            while (reader.Read() && !(reader.NodeType == XmlNodeType.EndElement && reader.Name == currentNode))
             {
                 if (reader.NodeType == XmlNodeType.Element)
                 {
@@ -599,43 +606,25 @@ namespace WaveSabreConvert
             }
         }
 
-        Dictionary<char, int> hexTable = new Dictionary<char, int>()
-        {
-            { '0', 0 },
-            { '1', 1 },
-            { '2', 2 },
-            { '3', 3 },
-            { '4', 4 },
-            { '5', 5 },
-            { '6', 6 },
-            { '7', 7 },
-            { '8', 8 },
-            { '9', 9 },
-            { 'a', 10 },
-            { 'b', 11 },
-            { 'c', 12 },
-            { 'd', 13 },
-            { 'e', 14 },
-            { 'f', 15 },
-        };
         void parseVstPresetBuffer(LiveProject.Device device)
         {
+            var currentNode = reader.Name;
             var rawData = new List<byte>();
-            while (reader.Read() && !(reader.NodeType == XmlNodeType.EndElement && reader.Name == "Buffer"))
+            while (reader.Read() && !(reader.NodeType == XmlNodeType.EndElement && reader.Name == currentNode))
             {
-                foreach (var line in reader.Value.Split('\n'))
+                var line = reader.Value.Replace("\t", "").Replace("\n", "").TrimStart().TrimEnd();
+                if (line.Length > 0)
                 {
-                    var trimmedLine = line.Trim().ToLower();
-                    if (trimmedLine.Length > 0)
+                    for (int i = 0; i < line.Length; i += 2)
                     {
-                        for (int i = 0; i < trimmedLine.Length; i += 2) rawData.Add((byte)(hexTable[trimmedLine[i]] * 16 + hexTable[trimmedLine[i + 1]]));
+                        rawData.Add(Convert.ToByte(line.Substring(i, 2), 16));
                     }
+                    device.RawData = rawData.ToArray();
                 }
             }
-            device.RawData = rawData.ToArray();
         }
 
-        void parseParameterList(LiveProject.Device device)
+        void parseParameterList(LiveProject.Device device, LiveProject.Track track)
         {
             while (reader.Read() && !(reader.NodeType == XmlNodeType.EndElement && reader.Name == "ParameterList"))
             {
@@ -644,14 +633,14 @@ namespace WaveSabreConvert
                     switch (reader.Name)
                     {
                         case "PluginFloatParameter":
-                            if (!reader.IsEmptyElement) parseFloatParameter(device);
+                            if (!reader.IsEmptyElement) parseFloatParameter(device, track);
                             break;
                     }
                 }
             }
         }
 
-        void parseFloatParameter(LiveProject.Device device)
+        void parseFloatParameter(LiveProject.Device device, LiveProject.Track track)
         {
             var floatParameter = new LiveProject.FloatParameter();
             while (reader.Read() && !(reader.NodeType == XmlNodeType.EndElement && reader.Name == "PluginFloatParameter"))
@@ -663,7 +652,9 @@ namespace WaveSabreConvert
                         case "ParameterId":
                             floatParameter.Id = getIntValueAttrib();
                             break;
-
+                        case "AutomationTarget":
+                            floatParameter.AutomationTarget = getIntAttrib("Id");
+                            break;
                         case "Events":
                             if (!reader.IsEmptyElement)
                             {
@@ -671,10 +662,13 @@ namespace WaveSabreConvert
                                 {
                                     if (reader.NodeType == XmlNodeType.Element && reader.Name == "FloatEvent")
                                     {
-                                        var e = new LiveProject.FloatParameter.Event();
+                                        var e = new LiveProject.Event();
                                         e.Time = getDoubleAttrib("Time");
                                         e.Value = (float)getDoubleValueAttrib();
-                                        floatParameter.Events.Add(e);
+                                        if (e.Time >= 0)
+                                        {
+                                            floatParameter.Events.Add(e);
+                                        }
                                     }
                                 }
                             }
@@ -682,7 +676,81 @@ namespace WaveSabreConvert
                     }
                 }
             }
-            device.FloatParameters.Add(floatParameter);
+
+            // new special handling of automation events for Live 10
+            // they appear higher up in the XML so are now stored in a separate object on the track
+            // and linked together here.
+            if (floatParameter.Events.Count == 0)
+            {
+                foreach (var auto in track.AutomationEnvelopes)
+                {
+                    if (auto.PointeeId == floatParameter.AutomationTarget)
+                    {
+                        floatParameter.Events = auto.Events;
+                        break;
+                    }
+                }
+            }
+
+            if (floatParameter.Events.Count > 0)
+            {
+                device.FloatParameters.Add(floatParameter);
+            }
+        }
+
+        // new Live 10 automation storage
+        void parseAutomationEnvelopes(LiveProject.Track track)
+        {
+            var currentNode = reader.Name;
+            while (reader.Read() && !(reader.NodeType == XmlNodeType.EndElement && reader.Name == currentNode))
+            {
+                if (reader.NodeType == XmlNodeType.Element)
+                {
+                    switch (reader.Name)
+                    {
+                        case "AutomationEnvelope":
+                            parseAutomationEnvelope(track);
+                            break;
+                    }
+                }
+            }
+        }
+
+        void parseAutomationEnvelope(LiveProject.Track track)
+        {
+            var currentNode = reader.Name;
+            var automation = new LiveProject.AutomationEnvelope();
+            while (reader.Read() && !(reader.NodeType == XmlNodeType.EndElement && reader.Name == currentNode))
+            {
+                if (reader.NodeType == XmlNodeType.Element)
+                {
+                    switch (reader.Name)
+                    {
+                        case "PointeeId":
+                            automation.PointeeId = getIntValueAttrib();
+                            break;
+                        case "Events":
+                            if (!reader.IsEmptyElement)
+                            {
+                                while (reader.Read() && !(reader.NodeType == XmlNodeType.EndElement && reader.Name == "Events"))
+                                {
+                                    if (reader.NodeType == XmlNodeType.Element && reader.Name == "FloatEvent")
+                                    {
+                                        var e = new LiveProject.Event();
+                                        e.Time = getDoubleAttrib("Time");
+                                        e.Value = (float)getDoubleValueAttrib();
+                                        if (e.Time >= 0)
+                                        {
+                                            automation.Events.Add(e);
+                                        }
+                                    }
+                                }
+                            }
+                            break;
+                    }
+                }
+            }
+            track.AutomationEnvelopes.Add(automation);
         }
     }
 }

--- a/WaveSabreConvert/LiveProject.cs
+++ b/WaveSabreConvert/LiveProject.cs
@@ -19,15 +19,22 @@ namespace WaveSabreConvert
             }
         }
 
+        public class Event
+        {
+            public double Time;
+            public float Value;
+        }
+
+        public class AutomationEnvelope
+        {
+            public int PointeeId;
+            public List<Event> Events = new List<Event>();
+        }
+
         public class FloatParameter
         {
-            public class Event
-            {
-                public double Time;
-                public float Value;
-            }
-
             public int Id;
+            public int AutomationTarget = -1;
             public List<Event> Events = new List<Event>();
         }
 
@@ -72,6 +79,7 @@ namespace WaveSabreConvert
             public List<Device> Devices = new List<Device>();
             public List<MidiClip> MidiClips = new List<MidiClip>();
             public string TrackGroupId;
+            public List<AutomationEnvelope> AutomationEnvelopes = new List<AutomationEnvelope>();
         }
 
         public List<Track> Tracks = new List<Track>();


### PR DESCRIPTION
support for ableton live 10
automations stored higher up so these are now logged and linked later
hex look up replaced with string convert
most parser functions now log current node rather than being specific
removed negative automation params
fix for zero spaced triplets (samples instead of time)
