### PR TITLE
add VSTSDK option

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,19 +2,18 @@ version: '{build}'
 image: Visual Studio 2013
 
 cache:
-  - Vst3.x
+  - C:\tmp\VST3 SDK
 
 install:
   - ps: |
-      if (-Not (Test-Path ".\Vst3.x\public.sdk")) {
+      if (-Not (Test-Path "C:\tmp\VST3 SDK")) {
         Invoke-WebRequest "https://www.steinberg.net/sdk_downloads/vstsdk366_27_06_2016_build_61.zip" -OutFile "vstsdk.zip"
         Expand-Archive "vstsdk.zip" "C:\tmp"
-        Copy-Item -Path "C:\tmp\VST3 SDK\*" -Destination ".\Vst3.x" -Recurse
       }
 
 build_script:
   - mkdir build
   - cd build
-  - cmake ..
+  - cmake -DVSTSDK3_DIR="C:/tmp/VST3 SDK" ..
   - msbuild /v:minimal /nologo WaveSabre.sln
   - cd ..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ if(MSVC)
 	string(REPLACE "/EHsc" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
 endif()
 
+option(VSTSDK3_DIR "VSTSDK location" "./Vst3.x/")
+
 # shared code
 add_subdirectory(WaveSabreCore)
 add_subdirectory(WaveSabrePlayerLib)

--- a/Docs/Home.md
+++ b/Docs/Home.md
@@ -14,6 +14,7 @@ WaveSabre has a new [CMake](https://cmake.org/) based build-system that can gene
   - Alternatively, you can install CMake from [Chocolatey](https://chocolatey.org/) or other package managers.
 - Run `cmake -B build` to generate the Visual Studio project files and solution
   - Optionally, you can also specify `-DVSTDIR=<some-path>` to copy the VST plugins into your DAW's VST plugin directory upon build.
+  - You can also specify `-DVSTSDK3_DIR=<dir>` to use a VSTSDK from outside of the source-tree.
 - Open the generated solution from the build directory, and proceed as normal.
 
 ## New Device Check List

--- a/WaveSabreVstLib/CMakeLists.txt
+++ b/WaveSabreVstLib/CMakeLists.txt
@@ -1,42 +1,42 @@
 add_library(WaveSabreVstLib
-	../Vst3.x/public.sdk/source/vst2.x/audioeffect.cpp
-	../Vst3.x/public.sdk/source/vst2.x/audioeffectx.cpp
-	../Vst3.x/public.sdk/source/vst2.x/vstplugmain.cpp
-	../Vst3.x/vstgui.sf/libpng/png.c
-	../Vst3.x/vstgui.sf/libpng/pngerror.c
-	../Vst3.x/vstgui.sf/libpng/pnggccrd.c
-	../Vst3.x/vstgui.sf/libpng/pngget.c
-	../Vst3.x/vstgui.sf/libpng/pngmem.c
-	../Vst3.x/vstgui.sf/libpng/pngpread.c
-	../Vst3.x/vstgui.sf/libpng/pngread.c
-	../Vst3.x/vstgui.sf/libpng/pngrio.c
-	../Vst3.x/vstgui.sf/libpng/pngrtran.c
-	../Vst3.x/vstgui.sf/libpng/pngrutil.c
-	../Vst3.x/vstgui.sf/libpng/pngset.c
-	../Vst3.x/vstgui.sf/libpng/pngtrans.c
-	../Vst3.x/vstgui.sf/libpng/pngvcrd.c
-	../Vst3.x/vstgui.sf/libpng/pngwio.c
-	../Vst3.x/vstgui.sf/libpng/pngwrite.c
-	../Vst3.x/vstgui.sf/libpng/pngwtran.c
-	../Vst3.x/vstgui.sf/libpng/pngwutil.c
-	../Vst3.x/vstgui.sf/vstgui/aeffguieditor.cpp
-	../Vst3.x/vstgui.sf/vstgui/cfileselector.cpp
-	../Vst3.x/vstgui.sf/vstgui/vstcontrols.cpp
-	../Vst3.x/vstgui.sf/vstgui/vstgui.cpp
-	../Vst3.x/vstgui.sf/vstgui/vstguidebug.cpp
-	../Vst3.x/vstgui.sf/zlib/adler32.c
-	../Vst3.x/vstgui.sf/zlib/compress.c
-	../Vst3.x/vstgui.sf/zlib/crc32.c
-	../Vst3.x/vstgui.sf/zlib/deflate.c
-	../Vst3.x/vstgui.sf/zlib/gzio.c
-	../Vst3.x/vstgui.sf/zlib/infback.c
-	../Vst3.x/vstgui.sf/zlib/inffast.c
-	../Vst3.x/vstgui.sf/zlib/inflate.c
-	../Vst3.x/vstgui.sf/zlib/inftrees.c
-	../Vst3.x/vstgui.sf/zlib/minigzip.c
-	../Vst3.x/vstgui.sf/zlib/trees.c
-	../Vst3.x/vstgui.sf/zlib/uncompr.c
-	../Vst3.x/vstgui.sf/zlib/zutil.c
+	${VSTSDK3_DIR}/public.sdk/source/vst2.x/audioeffect.cpp
+	${VSTSDK3_DIR}/public.sdk/source/vst2.x/audioeffectx.cpp
+	${VSTSDK3_DIR}/public.sdk/source/vst2.x/vstplugmain.cpp
+	${VSTSDK3_DIR}/vstgui.sf/libpng/png.c
+	${VSTSDK3_DIR}/vstgui.sf/libpng/pngerror.c
+	${VSTSDK3_DIR}/vstgui.sf/libpng/pnggccrd.c
+	${VSTSDK3_DIR}/vstgui.sf/libpng/pngget.c
+	${VSTSDK3_DIR}/vstgui.sf/libpng/pngmem.c
+	${VSTSDK3_DIR}/vstgui.sf/libpng/pngpread.c
+	${VSTSDK3_DIR}/vstgui.sf/libpng/pngread.c
+	${VSTSDK3_DIR}/vstgui.sf/libpng/pngrio.c
+	${VSTSDK3_DIR}/vstgui.sf/libpng/pngrtran.c
+	${VSTSDK3_DIR}/vstgui.sf/libpng/pngrutil.c
+	${VSTSDK3_DIR}/vstgui.sf/libpng/pngset.c
+	${VSTSDK3_DIR}/vstgui.sf/libpng/pngtrans.c
+	${VSTSDK3_DIR}/vstgui.sf/libpng/pngvcrd.c
+	${VSTSDK3_DIR}/vstgui.sf/libpng/pngwio.c
+	${VSTSDK3_DIR}/vstgui.sf/libpng/pngwrite.c
+	${VSTSDK3_DIR}/vstgui.sf/libpng/pngwtran.c
+	${VSTSDK3_DIR}/vstgui.sf/libpng/pngwutil.c
+	${VSTSDK3_DIR}/vstgui.sf/vstgui/aeffguieditor.cpp
+	${VSTSDK3_DIR}/vstgui.sf/vstgui/cfileselector.cpp
+	${VSTSDK3_DIR}/vstgui.sf/vstgui/vstcontrols.cpp
+	${VSTSDK3_DIR}/vstgui.sf/vstgui/vstgui.cpp
+	${VSTSDK3_DIR}/vstgui.sf/vstgui/vstguidebug.cpp
+	${VSTSDK3_DIR}/vstgui.sf/zlib/adler32.c
+	${VSTSDK3_DIR}/vstgui.sf/zlib/compress.c
+	${VSTSDK3_DIR}/vstgui.sf/zlib/crc32.c
+	${VSTSDK3_DIR}/vstgui.sf/zlib/deflate.c
+	${VSTSDK3_DIR}/vstgui.sf/zlib/gzio.c
+	${VSTSDK3_DIR}/vstgui.sf/zlib/infback.c
+	${VSTSDK3_DIR}/vstgui.sf/zlib/inffast.c
+	${VSTSDK3_DIR}/vstgui.sf/zlib/inflate.c
+	${VSTSDK3_DIR}/vstgui.sf/zlib/inftrees.c
+	${VSTSDK3_DIR}/vstgui.sf/zlib/minigzip.c
+	${VSTSDK3_DIR}/vstgui.sf/zlib/trees.c
+	${VSTSDK3_DIR}/vstgui.sf/zlib/uncompr.c
+	${VSTSDK3_DIR}/vstgui.sf/zlib/zutil.c
 	include/WaveSabreVstLib.h
 	src/ImageManager.cpp
 	src/NoTextCOptionMenu.cpp
@@ -46,10 +46,10 @@ add_library(WaveSabreVstLib
 target_include_directories(WaveSabreVstLib PUBLIC
 	include
 	../WaveSabreCore/include
-	../Vst3.x/vstgui.sf/zlib
-	../Vst3.x/vstgui.sf/libpng
-	../Vst3.x/public.sdk/source/vst2.x
-	../Vst3.x)
+	${VSTSDK3_DIR}/vstgui.sf/zlib
+	${VSTSDK3_DIR}/vstgui.sf/libpng
+	${VSTSDK3_DIR}/public.sdk/source/vst2.x
+	${VSTSDK3_DIR})
 
 target_compile_definitions(WaveSabreVstLib PUBLIC USE_LIBPNG)
 


### PR DESCRIPTION
Here's a few patches for cleaning things up a bit:
1. A `VSTSDK3_DIR` option has been added, that allows specifying the path to the VSTSDK instead of requiring it to be copied into the source-tree. The default is still to keep it inside the source-tree, though.
2. Finally, we switch the CI over to using the new option, which saves us a copy when building uncached. This should speed things up a tiny bit, but probably isn't a big deal.

It's really point 1 here that matters to me. Allowing to specify an out-of-tree directory allows me to carelessly "git clean" things without breaking the build (I also use out-of-tree build directories, which already works fine).

Dunno, perhaps this is useful to others?