### PR TITLE
Ignore deprecated functions in VSTSDK code

### DIFF
--- a/WaveSabreVstLib/CMakeLists.txt
+++ b/WaveSabreVstLib/CMakeLists.txt
@@ -56,4 +56,7 @@ target_compile_definitions(WaveSabreVstLib PUBLIC USE_LIBPNG)
 if(MSVC)
 	target_compile_definitions(WaveSabreVstLib PUBLIC _CRT_SECURE_NO_WARNINGS)
 	target_compile_options(WaveSabreVstLib PUBLIC /EHsc)
+	set_source_files_properties(../Vst3.x/vstgui.sf/vstgui/vstgui.cpp
+		../Vst3.x/vstgui.sf/zlib/minigzip.c
+		PROPERTIES COMPILE_OPTIONS /wd4996)
 endif()


### PR DESCRIPTION
We don't control the code in the VSTSDK, so the best thing we can really do there is to just ignore the warnings.

It's not like this is a big deal anyway; Microsoft never really removes anything in practice. But even if they would do, we would notice due to build-errors. And then we could either apply a patch before we we compile, or inject some macros to remap the functions. But for now, let's keep this simple.

This seems to make the current CI run warning-free as of writing.

Due to touching the VSTSDK source-files, this PR conflicts with #32. It's easy to resolve, though, and either can easily be rebased on the other. Just worth noting ;)