### PR TITLE
WIP: WaveSabreCore: simplify cos-table computation

### DIFF
--- a/WaveSabreCore/src/Helpers.cpp
+++ b/WaveSabreCore/src/Helpers.cpp
@@ -100,24 +100,6 @@ done:
 	}
 }
 
-static __declspec(naked) double __vectorcall fpuCos(double x)
-{
-	__asm
-	{
-		sub esp, 8
-
-		movsd mmword ptr [esp], xmm0
-		fld qword ptr [esp]
-		fcos
-		fstp qword ptr [esp]
-		movsd xmm0, mmword ptr [esp]
-
-		add esp, 8
-
-		ret
-	}
-}
-
 namespace WaveSabreCore
 {
 	double Helpers::CurrentSampleRate = 44100.0;
@@ -132,10 +114,15 @@ namespace WaveSabreCore
 	{
 		RandomSeed = 1;
 
+		const double delta = (M_PI * 2) / fastCosTabSize;
+		const double sd = sin(delta), cd = cos(delta);
+		double x = 0, y = 1;
 		for (int i = 0; i < fastCosTabSize + 1; i++)
 		{
-			double phase = double(i) * ((M_PI * 2) / fastCosTabSize);
-			fastCosTab[i] = fpuCos(phase);
+			fastCosTab[i] = y;
+			double tx = x * cd - y * sd;
+			y = x * sd + y * cd;
+			x = tx;
 		}
 	}
 


### PR DESCRIPTION
We don't need to use run-time trig functions here, because the step
between each entry is the same. So instead, let's calculate the
coefficients of a 2D rotation matrix using constant expressions, which
should give the same result, barring any accumulation errors.

Since we're using double precision floats and the LUT is of limited
size, the max error accumulated are a negligible 2.22045e-14, compared
to the CRT cos() function.

Note: I've marked this as WIP, so don't merge this just yet. This is kinda
written "blindly" without verifying if the resulting code is smaller or not.
I suspect it is, but this needs to be verified. My excuse is that I was on a
Linux machine when I wrote this ;)