### PR TITLE
WaveSabreVstLib: fixup paths to vstsdk

### DIFF
--- a/WaveSabreVstLib/CMakeLists.txt
+++ b/WaveSabreVstLib/CMakeLists.txt
@@ -56,7 +56,7 @@ target_compile_definitions(WaveSabreVstLib PUBLIC USE_LIBPNG)
 if(MSVC)
 	target_compile_definitions(WaveSabreVstLib PUBLIC _CRT_SECURE_NO_WARNINGS)
 	target_compile_options(WaveSabreVstLib PUBLIC /EHsc)
-	set_source_files_properties(../Vst3.x/vstgui.sf/vstgui/vstgui.cpp
-		../Vst3.x/vstgui.sf/zlib/minigzip.c
+	set_source_files_properties(${VSTSDK3_DIR}/vstgui.sf/vstgui/vstgui.cpp
+		${VSTSDK3_DIR}/vstgui.sf/zlib/minigzip.c
 		PROPERTIES COMPILE_OPTIONS /wd4996)
 endif()


### PR DESCRIPTION
Since #32 landed, the path in #33 was no longer correct. I pointed this
out in the cover-letter, but I guess it was rather confusing. Sorry for that.

Luckily, it just means that #33 isn't effective if VSTSDK3_DIR is
overridden. And here's the fix to make it always effective.