### PR TITLE
switch out fpuPow variants for fpuExp2

### DIFF
--- a/WaveSabreCore/include/WaveSabreCore/Helpers.h
+++ b/WaveSabreCore/include/WaveSabreCore/Helpers.h
@@ -21,18 +21,8 @@ namespace WaveSabreCore
 
 		static float RandFloat();
 
-		static double Pow(double x, double y);
-		static float PowF(float x, float y);
-
-		static inline double Exp2(double x)
-		{
-			return Pow(2.0, x);
-		}
-
-		static inline float Exp2F(float x)
-		{
-			return PowF(2.0f, x);
-		}
+		static double Exp2(double x);
+		static float Exp2F(float x);
 
 		static inline float Exp10F(float x)
 		{

--- a/WaveSabreCore/include/WaveSabreCore/Helpers.h
+++ b/WaveSabreCore/include/WaveSabreCore/Helpers.h
@@ -21,6 +21,21 @@ namespace WaveSabreCore
 		static double Pow(double x, double y);
 		static float PowF(float x, float y);
 
+		static inline double Exp2(double x)
+		{
+			return Pow(2.0, x);
+		}
+
+		static inline float Exp2F(float x)
+		{
+			return PowF(2.0f, x);
+		}
+
+		static inline float Exp10F(float x)
+		{
+			return PowF(10.0, x);
+		}
+
 		static inline double Pow2(double x)
 		{
 			return x * x;

--- a/WaveSabreCore/include/WaveSabreCore/Helpers.h
+++ b/WaveSabreCore/include/WaveSabreCore/Helpers.h
@@ -5,6 +5,9 @@
 #include "Twister.h"
 #include "SynthDevice.h"
 
+#define _USE_MATH_DEFINES
+#include <math.h>
+
 namespace WaveSabreCore
 {
 	class Helpers
@@ -33,7 +36,8 @@ namespace WaveSabreCore
 
 		static inline float Exp10F(float x)
 		{
-			return PowF(10.0, x);
+			const float scale = (float)(M_LN10 / M_LN2);
+			return Exp2F(x * scale);
 		}
 
 		static inline double Pow2(double x)

--- a/WaveSabreCore/include/WaveSabreCore/Helpers.h
+++ b/WaveSabreCore/include/WaveSabreCore/Helpers.h
@@ -21,6 +21,21 @@ namespace WaveSabreCore
 		static double Pow(double x, double y);
 		static float PowF(float x, float y);
 
+		static inline double Pow2(double x)
+		{
+			return x * x;
+		}
+
+		static inline double Pow4(double x)
+		{
+			return Pow2(Pow2(x));
+		}
+
+		static inline float Pow2F(float x)
+		{
+			return x * x;
+		}
+
 		static double FastCos(double x);
 		static double FastSin(double x);
 

--- a/WaveSabreCore/src/BiquadFilter.cpp
+++ b/WaveSabreCore/src/BiquadFilter.cpp
@@ -51,7 +51,7 @@ namespace WaveSabreCore
 
 			case BiquadFilterType::Peak:
 				{
-					float A = Helpers::PowF(10.0f, gain / 40.0f);
+					float A = Helpers::Exp10F(gain / 40.0f);
 					a0 = 1.0f + alpha / A;
 					a1 = -2.0f * (float)Helpers::FastCos(w0);
 					a2 = 1.0f - alpha / A;

--- a/WaveSabreCore/src/Crusher.cpp
+++ b/WaveSabreCore/src/Crusher.cpp
@@ -22,7 +22,7 @@ namespace WaveSabreCore
 	void Crusher::Run(double songPosition, float **inputs, float **outputs, int numSamples)
 	{
 		float step = 1.0f / Helpers::PowF(2.0f, (1.0f - vertical) * 15.0f + 1.0f);
-		float freq = Helpers::PowF(1.0f - horizontal, 2.0f);
+		float freq = Helpers::Pow2F(1.0f - horizontal);
 		for (int i = 0; i < 2; i++)
 		{
 			for (int j = 0; j < numSamples; j++)

--- a/WaveSabreCore/src/Crusher.cpp
+++ b/WaveSabreCore/src/Crusher.cpp
@@ -21,7 +21,7 @@ namespace WaveSabreCore
 
 	void Crusher::Run(double songPosition, float **inputs, float **outputs, int numSamples)
 	{
-		float step = 1.0f / Helpers::PowF(2.0f, (1.0f - vertical) * 15.0f + 1.0f);
+		float step = 1.0f / Helpers::Exp2F((1.0f - vertical) * 15.0f + 1.0f);
 		float freq = Helpers::Pow2F(1.0f - horizontal);
 		for (int i = 0; i < 2; i++)
 		{

--- a/WaveSabreCore/src/Helpers.cpp
+++ b/WaveSabreCore/src/Helpers.cpp
@@ -342,7 +342,7 @@ namespace WaveSabreCore
 
 	double Helpers::ParamToVibratoFreq(float param)
 	{
-		return (Pow((double)param, 2.0) + .1) * 70.0;
+		return (Pow2((double)param) + .1) * 70.0;
 	}
 
 	float Helpers::VibratoFreqToParam(double vf)

--- a/WaveSabreCore/src/Helpers.cpp
+++ b/WaveSabreCore/src/Helpers.cpp
@@ -6,17 +6,15 @@
 
 #if defined(_MSC_VER) && defined(_M_IX86)
 // TODO: make assembly equivalent for x64 (use intrinsic ?)
-static __declspec(naked) double __vectorcall fpuPow(double x, double y)
+static __declspec(naked) double __vectorcall fpuExp2(double x)
 {
 	__asm
 	{
 		sub esp, 8
 
-		movsd mmword ptr [esp], xmm1
-		fld qword ptr [esp]
 		movsd mmword ptr [esp], xmm0
 		fld qword ptr [esp]
-		fyl2x
+
 		fld st(0)
 		frndint
 		fsubr st(1), st(0)
@@ -37,17 +35,15 @@ static __declspec(naked) double __vectorcall fpuPow(double x, double y)
 	}
 }
 
-static __declspec(naked) float __vectorcall fpuPowF(float x, float y)
+static __declspec(naked) float __vectorcall fpuExp2F(float x)
 {
 	__asm
 	{
 		sub esp, 8
 
-		movss mmword ptr [esp], xmm1
-		fld dword ptr [esp]
 		movss mmword ptr [esp], xmm0
 		fld dword ptr [esp]
-		fyl2x
+
 		fld st(0)
 		frndint
 		fsubr st(1), st(0)
@@ -123,7 +119,7 @@ namespace WaveSabreCore
 		if (x == 0.0)
 			return 1.0;
 
-		return fpuPow(2.0, x);
+		return fpuExp2(x);
 #else
 		return pow(2.0, x);
 #endif
@@ -135,7 +131,7 @@ namespace WaveSabreCore
 		if (x == 0.0f)
 			return 1.0f;
 
-		return fpuPowF(2.0f, x);
+		return fpuExp2F(x);
 #else
 		return powf(2.0f, x);
 #endif

--- a/WaveSabreCore/src/Helpers.cpp
+++ b/WaveSabreCore/src/Helpers.cpp
@@ -116,9 +116,6 @@ namespace WaveSabreCore
 	double Helpers::Exp2(double x)
 	{
 #if defined(_MSC_VER) && defined(_M_IX86)
-		if (x == 0.0)
-			return 1.0;
-
 		return fpuExp2(x);
 #else
 		return pow(2.0, x);
@@ -128,9 +125,6 @@ namespace WaveSabreCore
 	float Helpers::Exp2F(float x)
 	{
 #if defined(_MSC_VER) && defined(_M_IX86)
-		if (x == 0.0f)
-			return 1.0f;
-
 		return fpuExp2F(x);
 #else
 		return powf(2.0f, x);

--- a/WaveSabreCore/src/Helpers.cpp
+++ b/WaveSabreCore/src/Helpers.cpp
@@ -151,21 +151,21 @@ namespace WaveSabreCore
 		return (float)((RandomSeed *= 0x15a4e35) % 255) / 255.0f;
 	}
 
-	double Helpers::Pow(double x, double y)
+	double Helpers::Exp2(double x)
 	{
 #if defined(_MSC_VER) && defined(_M_IX86)
-		return fpuPow(x, y);
+		return fpuPow(2.0, x);
 #else
-		return pow(x, y);
+		return pow(2.0, x);
 #endif
 	}
 
-	float Helpers::PowF(float x, float y)
+	float Helpers::Exp2F(float x)
 	{
 #if defined(_MSC_VER) && defined(_M_IX86)
-		return fpuPowF(x, y);
+		return fpuPowF(2.0f, x);
 #else
-		return powf(x, y);
+		return powf(2.0f, x);
 #endif
 	}
 

--- a/WaveSabreCore/src/Helpers.cpp
+++ b/WaveSabreCore/src/Helpers.cpp
@@ -227,12 +227,12 @@ namespace WaveSabreCore
 
 	double Helpers::NoteToFreq(double note)
 	{
-		return 440.0 * Pow(2.0, (note - 69.0) / 12.0);
+		return 440.0 * Exp2((note - 69.0) / 12.0);
 	}
 
 	float Helpers::DbToScalar(float db)
 	{
-		return PowF(2.0f, db / 6.0f);
+		return Exp2F(db / 6.0f);
 	}
 
 	float Helpers::EnvValueToScalar(float value)

--- a/WaveSabreCore/src/Helpers.cpp
+++ b/WaveSabreCore/src/Helpers.cpp
@@ -12,22 +12,6 @@ static __declspec(naked) double __vectorcall fpuPow(double x, double y)
 	{
 		sub esp, 8
 
-		xorpd xmm2, xmm2
-
-		comisd xmm1, xmm2
-		jne base_test
-
-		fld1
-		jmp done
-
-base_test:
-		comisd xmm0, xmm2
-		jne calc_pow
-
-		fldz
-		jmp done
-
-calc_pow:
 		movsd mmword ptr [esp], xmm1
 		fld qword ptr [esp]
 		movsd mmword ptr [esp], xmm0
@@ -44,7 +28,6 @@ calc_pow:
 		fscale
 		fstp st(1)
 
-done:
 		fstp qword ptr [esp]
 		movsd xmm0, mmword ptr [esp]
 
@@ -60,22 +43,6 @@ static __declspec(naked) float __vectorcall fpuPowF(float x, float y)
 	{
 		sub esp, 8
 
-		xorps xmm2, xmm2
-
-		comiss xmm1, xmm2
-		jne base_test
-
-		fld1
-		jmp done
-
-base_test:
-		comiss xmm0, xmm2
-		jne calc_pow
-
-		fldz
-		jmp done
-
-calc_pow:
 		movss mmword ptr [esp], xmm1
 		fld dword ptr [esp]
 		movss mmword ptr [esp], xmm0
@@ -92,7 +59,6 @@ calc_pow:
 		fscale
 		fstp st(1)
 
-done:
 		fstp dword ptr [esp]
 		movss xmm0, mmword ptr [esp]
 
@@ -154,6 +120,9 @@ namespace WaveSabreCore
 	double Helpers::Exp2(double x)
 	{
 #if defined(_MSC_VER) && defined(_M_IX86)
+		if (x == 0.0)
+			return 1.0;
+
 		return fpuPow(2.0, x);
 #else
 		return pow(2.0, x);
@@ -163,6 +132,9 @@ namespace WaveSabreCore
 	float Helpers::Exp2F(float x)
 	{
 #if defined(_MSC_VER) && defined(_M_IX86)
+		if (x == 0.0f)
+			return 1.0f;
+
 		return fpuPowF(2.0f, x);
 #else
 		return powf(2.0f, x);

--- a/WaveSabreCore/src/SamplePlayer.cpp
+++ b/WaveSabreCore/src/SamplePlayer.cpp
@@ -26,7 +26,7 @@ namespace WaveSabreCore
 
 	void SamplePlayer::CalcPitch(double note)
 	{
-		double freqDelta = Helpers::Pow(2.0, (note / 12.0));
+		double freqDelta = Helpers::Exp2(note / 12.0);
 		if (!reverse)
 		{
 			sampleDelta = freqDelta;

--- a/WaveSabreCore/src/Scissor.cpp
+++ b/WaveSabreCore/src/Scissor.cpp
@@ -25,7 +25,7 @@ namespace WaveSabreCore
 		}
 		else
 		{
-			driveScalar = 1.0f + Helpers::PowF((drive - .2f) * 5.0f, 2.0f) * 5.0f;
+			driveScalar = 1.0f + Helpers::Pow2F((drive - .2f) * 5.0f) * 5.0f;
 		}
 
 		for (int i = 0; i < 2; i++)

--- a/WaveSabreCore/src/SynthDevice.cpp
+++ b/WaveSabreCore/src/SynthDevice.cpp
@@ -249,7 +249,7 @@ namespace WaveSabreCore
 		slideActive = true;
 		destinationNote = note;
 		
-		double slideTime = 10.f * Helpers::Pow(this->GetSynthDevice()->Slide,4.0);
+		double slideTime = 10.f * Helpers::Pow4(this->GetSynthDevice()->Slide);
 		slideDelta = ((double)note - currentNote) / (Helpers::CurrentSampleRate * slideTime);
 		slideSamples = (int)(Helpers::CurrentSampleRate * slideTime);
 	}


### PR DESCRIPTION
It turns out, we're don't really need the full flexibility of Pow(x, y). Instead, what we need is these:
1. Pow(x, 2)
2. Pow(x, 4)
3. Pow(2, x)
4. Pow(10, x)

The first two are trivially expressible as normal C++ floating-point multiplies. This seems to end up with exactly the same code-size, both before and after compression.

Number four can also trivially be expressed in terms of number three. This means we're left with an exp2-variant. And Exp2 is a bit easier to handle than Pow, especially due to less needed special-cases.

The end result is a saving of 36 bytes.

A follow-up question to this series might become: do we *really* need both float and double variants of these? But I guess @yupferris knows more about the rationale here...