### PR TITLE
support building on x64

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,10 @@
 version: '{build}'
 image: Visual Studio 2013
 
+platform:
+  - Win32
+  - x64
+
 cache:
   - C:\tmp\VST3 SDK
 
@@ -14,7 +18,7 @@ install:
 build_script:
   - mkdir build
   - cd build
-  - cmake -DVSTSDK3_DIR="C:/tmp/VST3 SDK" ..
+  - cmake -DCMAKE_GENERATOR_PLATFORM=%PLATFORM% -DVSTSDK3_DIR="C:/tmp/VST3 SDK" ..
   - msbuild /v:minimal /nologo WaveSabre.sln
   - msbuild /v:minimal /nologo /property:Configuration="MinSizeRel" WaveSabre.sln
   - cd ..

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -51,6 +51,58 @@
       "cmakeCommandArgs": "",
       "buildCommandArgs": "-v",
       "ctestCommandArgs": ""
+    },
+    {
+      "name": "Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [
+        "msvc_x64"
+      ],
+      "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
+      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": ""
+    },
+    {
+      "name": "Release",
+      "generator": "Ninja",
+      "configurationType": "Release",
+      "inheritEnvironments": [
+        "msvc_x64"
+      ],
+      "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
+      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": ""
+    },
+    {
+      "name": "RelWithDebInfo",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "inheritEnvironments": [
+        "msvc_x64"
+      ],
+      "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
+      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": ""
+    },
+    {
+      "name": "MinSizeRel",
+      "generator": "Ninja",
+      "configurationType": "MinSizeRel",
+      "inheritEnvironments": [
+        "msvc_x64"
+      ],
+      "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
+      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": ""
     }
   ]
 }

--- a/Tests/PlayerTest/CMakeLists.txt
+++ b/Tests/PlayerTest/CMakeLists.txt
@@ -2,12 +2,17 @@ add_executable(PlayerTest main.cpp)
 target_link_libraries(PlayerTest WaveSabrePlayerLib)
 
 if(MSVC)
-	target_link_libraries(PlayerTest
-		$<$<CONFIG:MinSizeRel>:${CMAKE_CURRENT_SOURCE_DIR}/msvcrt_old.lib>)
-	set_property(TARGET PlayerTest APPEND_STRING PROPERTY LINK_FLAGS_MINSIZEREL
-		" /NODEFAULTLIB /SAFESEH:NO /MANIFEST:NO /LTCG /OPT:REF /OPT:ICF /DYNAMICBASE:NO")
+	if(${CMAKE_VS_PLATFORM_NAME} STREQUAL "Win32")
+		target_link_libraries(PlayerTest
+			$<$<CONFIG:MinSizeRel>:${CMAKE_CURRENT_SOURCE_DIR}/msvcrt_old.lib>)
+		set_property(TARGET PlayerTest APPEND_STRING PROPERTY LINK_FLAGS_MINSIZEREL
+			" /NODEFAULTLIB")
+	endif()
 
-	if(MSVC AND MSVC_VERSION GREATER 1900)
+	set_property(TARGET PlayerTest APPEND_STRING PROPERTY LINK_FLAGS_MINSIZEREL
+		" /SAFESEH:NO /MANIFEST:NO /LTCG /OPT:REF /OPT:ICF /DYNAMICBASE:NO")
+
+	if(${CMAKE_VS_PLATFORM_NAME} STREQUAL "Win32" AND MSVC_VERSION GREATER 1900)
 		target_compile_definitions(PlayerTest PRIVATE
 			$<$<CONFIG:MinSizeRel>:_NO_CRT_STDIO_INLINE>)
 	endif()

--- a/Vsts/Specimen/SpecimenEditor.cpp
+++ b/Vsts/Specimen/SpecimenEditor.cpp
@@ -167,7 +167,7 @@ void SpecimenEditor::setParameter(VstInt32 index, float value)
 
 					if (acmFormatChoose(&formatChoose)) throw exception("acmFormatChoose failed");
 
-					acmDriverEnum(driverEnumCallback, (DWORD)waveFormat, NULL);
+					acmDriverEnum(driverEnumCallback, (DWORD_PTR)waveFormat, NULL);
 					HACMDRIVER driver = NULL;
 					if (acmDriverOpen(&driver, driverId, 0)) throw exception("acmDriverOpen failed");
 
@@ -210,7 +210,7 @@ void SpecimenEditor::setParameter(VstInt32 index, float value)
 
 }
 
-BOOL __stdcall SpecimenEditor::driverEnumCallback(HACMDRIVERID driverId, DWORD dwInstance, DWORD fdwSupport)
+BOOL __stdcall SpecimenEditor::driverEnumCallback(HACMDRIVERID driverId, DWORD_PTR dwInstance, DWORD fdwSupport)
 {
 	ACMDRIVERDETAILS driverDetails;
 	driverDetails.cbStruct = sizeof(driverDetails);

--- a/Vsts/Specimen/SpecimenEditor.h
+++ b/Vsts/Specimen/SpecimenEditor.h
@@ -18,7 +18,7 @@ public:
 	virtual void setParameter(VstInt32 index, float value);
 
 private:
-	static BOOL __stdcall driverEnumCallback(HACMDRIVERID driverId, DWORD dwInstance, DWORD fdwSupport);
+	static BOOL __stdcall driverEnumCallback(HACMDRIVERID driverId, DWORD_PTR dwInstance, DWORD fdwSupport);
 	static BOOL __stdcall formatEnumCallback(HACMDRIVERID driverId, LPACMFORMATDETAILS formatDetails, DWORD_PTR dwInstance, DWORD fdwSupport);
 
 	static HACMDRIVERID driverId;

--- a/Vsts/Thunder/ThunderEditor.cpp
+++ b/Vsts/Thunder/ThunderEditor.cpp
@@ -108,7 +108,7 @@ void ThunderEditor::setParameter(VstInt32 index, float value)
 
 					if (acmFormatChoose(&formatChoose)) throw exception("acmFormatChoose failed");
 
-					acmDriverEnum(driverEnumCallback, (DWORD)waveFormat, NULL);
+					acmDriverEnum(driverEnumCallback, (DWORD_PTR)waveFormat, NULL);
 					HACMDRIVER driver = NULL;
 					if (acmDriverOpen(&driver, driverId, 0)) throw exception("acmDriverOpen failed");
 
@@ -147,7 +147,7 @@ void ThunderEditor::setParameter(VstInt32 index, float value)
 	}
 }
 
-BOOL __stdcall ThunderEditor::driverEnumCallback(HACMDRIVERID driverId, DWORD dwInstance, DWORD fdwSupport)
+BOOL __stdcall ThunderEditor::driverEnumCallback(HACMDRIVERID driverId, DWORD_PTR dwInstance, DWORD fdwSupport)
 {
 	ACMDRIVERDETAILS driverDetails;
 	driverDetails.cbStruct = sizeof(driverDetails);

--- a/Vsts/Thunder/ThunderEditor.h
+++ b/Vsts/Thunder/ThunderEditor.h
@@ -19,7 +19,7 @@ public:
 	virtual void setParameter(VstInt32 index, float value);
 
 private:
-	static BOOL __stdcall driverEnumCallback(HACMDRIVERID driverId, DWORD dwInstance, DWORD fdwSupport);
+	static BOOL __stdcall driverEnumCallback(HACMDRIVERID driverId, DWORD_PTR dwInstance, DWORD fdwSupport);
 	static BOOL __stdcall formatEnumCallback(HACMDRIVERID driverId, LPACMFORMATDETAILS formatDetails, DWORD_PTR dwInstance, DWORD fdwSupport);
 
 	static HACMDRIVERID driverId;

--- a/WaveSabreCore/include/WaveSabreCore/Specimen.h
+++ b/WaveSabreCore/include/WaveSabreCore/Specimen.h
@@ -99,8 +99,8 @@ namespace WaveSabreCore
 			float velocity;
 		};
 
-		static BOOL __stdcall driverEnumCallback(HACMDRIVERID driverId, DWORD dwInstance, DWORD fdwSupport);
-		static BOOL __stdcall formatEnumCallback(HACMDRIVERID driverId, LPACMFORMATDETAILS formatDetails, DWORD dwInstance, DWORD fdwSupport);
+		static BOOL __stdcall driverEnumCallback(HACMDRIVERID driverId, DWORD_PTR dwInstance, DWORD fdwSupport);
+		static BOOL __stdcall formatEnumCallback(HACMDRIVERID driverId, LPACMFORMATDETAILS formatDetails, DWORD_PTR dwInstance, DWORD fdwSupport);
 
 		static HACMDRIVERID driverId;
 

--- a/WaveSabreCore/include/WaveSabreCore/Thunder.h
+++ b/WaveSabreCore/include/WaveSabreCore/Thunder.h
@@ -43,8 +43,8 @@ namespace WaveSabreCore
 			int samplePos;
 		};
 
-		static BOOL __stdcall driverEnumCallback(HACMDRIVERID driverId, DWORD dwInstance, DWORD fdwSupport);
-		static BOOL __stdcall formatEnumCallback(HACMDRIVERID driverId, LPACMFORMATDETAILS formatDetails, DWORD dwInstance, DWORD fdwSupport);
+		static BOOL __stdcall driverEnumCallback(HACMDRIVERID driverId, DWORD_PTR dwInstance, DWORD fdwSupport);
+		static BOOL __stdcall formatEnumCallback(HACMDRIVERID driverId, LPACMFORMATDETAILS formatDetails, DWORD_PTR dwInstance, DWORD fdwSupport);
 
 		static HACMDRIVERID driverId;
 

--- a/WaveSabreCore/src/GmDls.cpp
+++ b/WaveSabreCore/src/GmDls.cpp
@@ -16,7 +16,7 @@ namespace WaveSabreCore
 		for (int i = 0; gmDlsFile == INVALID_HANDLE_VALUE; i++)
 		{
 			OFSTRUCT reOpenBuff;
-			gmDlsFile = (HANDLE)OpenFile(gmDlsPaths[i], &reOpenBuff, OF_READ);
+			gmDlsFile = (HANDLE)(UINT_PTR)OpenFile(gmDlsPaths[i], &reOpenBuff, OF_READ);
 		}
 
 		auto gmDlsFileSize = GetFileSize(gmDlsFile, NULL);

--- a/WaveSabreCore/src/Helpers.cpp
+++ b/WaveSabreCore/src/Helpers.cpp
@@ -4,6 +4,8 @@
 #define _USE_MATH_DEFINES
 #include <math.h>
 
+#if defined(_MSC_VER) && defined(_M_IX86)
+// TODO: make assembly equivalent for x64 (use intrinsic ?)
 static __declspec(naked) double __vectorcall fpuPow(double x, double y)
 {
 	__asm
@@ -117,6 +119,7 @@ static __declspec(naked) double __vectorcall fpuCos(double x)
 		ret
 	}
 }
+#endif // defined(_MSC_VER) && defined(_M_IX86)
 
 namespace WaveSabreCore
 {
@@ -135,7 +138,11 @@ namespace WaveSabreCore
 		for (int i = 0; i < fastCosTabSize + 1; i++)
 		{
 			double phase = double(i) * ((M_PI * 2) / fastCosTabSize);
+#if defined(_MSC_VER) && defined(_M_IX86)
 			fastCosTab[i] = fpuCos(phase);
+#else
+			fastCosTab[i] = cos(phase);
+#endif
 		}
 	}
 
@@ -146,12 +153,20 @@ namespace WaveSabreCore
 
 	double Helpers::Pow(double x, double y)
 	{
+#if defined(_MSC_VER) && defined(_M_IX86)
 		return fpuPow(x, y);
+#else
+		return pow(x, y);
+#endif
 	}
 
 	float Helpers::PowF(float x, float y)
 	{
+#if defined(_MSC_VER) && defined(_M_IX86)
 		return fpuPowF(x, y);
+#else
+		return powf(x, y);
+#endif
 	}
 
 	double Helpers::FastCos(double x)

--- a/WaveSabreCore/src/Specimen.cpp
+++ b/WaveSabreCore/src/Specimen.cpp
@@ -391,7 +391,7 @@ namespace WaveSabreCore
 		samplePlayer.CalcPitch(GetNote() - 60 + Detune + specimen->fineTune * 2.0f - 1.0f + SpecimenVoice::coarseDetune(specimen->coarseTune));
 	}
 
-	BOOL __stdcall Specimen::driverEnumCallback(HACMDRIVERID driverId, DWORD dwInstance, DWORD fdwSupport)
+	BOOL __stdcall Specimen::driverEnumCallback(HACMDRIVERID driverId, DWORD_PTR dwInstance, DWORD fdwSupport)
 	{
 		if (Specimen::driverId) return 1;
 
@@ -417,7 +417,7 @@ namespace WaveSabreCore
 		return 1;
 	}
 
-	BOOL __stdcall Specimen::formatEnumCallback(HACMDRIVERID driverId, LPACMFORMATDETAILS formatDetails, DWORD dwInstance, DWORD fdwSupport)
+	BOOL __stdcall Specimen::formatEnumCallback(HACMDRIVERID driverId, LPACMFORMATDETAILS formatDetails, DWORD_PTR dwInstance, DWORD fdwSupport)
 	{
 		if (formatDetails->pwfx->wFormatTag == WAVE_FORMAT_GSM610 &&
 			formatDetails->pwfx->nChannels == 1 &&

--- a/WaveSabreCore/src/Specimen.cpp
+++ b/WaveSabreCore/src/Specimen.cpp
@@ -195,7 +195,7 @@ namespace WaveSabreCore
 		auto compressedDataSize = compressedSize;
 		auto paramSize = (int)ParamIndices::NumParams * sizeof(float);
 		auto chunkSizeSize = sizeof(int);
-		auto size = headerSize + waveFormatSize + compressedSize + paramSize + chunkSizeSize;
+		int size = (int)(headerSize + waveFormatSize + compressedSize + paramSize + chunkSizeSize);
 
 		// (Re)allocate chunk data
 		if (chunkData) delete [] chunkData;

--- a/WaveSabreCore/src/Thunder.cpp
+++ b/WaveSabreCore/src/Thunder.cpp
@@ -147,7 +147,7 @@ namespace WaveSabreCore
 		samplePos = 0;
 	}
 
-	BOOL __stdcall Thunder::driverEnumCallback(HACMDRIVERID driverId, DWORD dwInstance, DWORD fdwSupport)
+	BOOL __stdcall Thunder::driverEnumCallback(HACMDRIVERID driverId, DWORD_PTR dwInstance, DWORD fdwSupport)
 	{
 		if (Thunder::driverId) return 1;
 
@@ -173,7 +173,7 @@ namespace WaveSabreCore
 		return 1;
 	}
 
-	BOOL __stdcall Thunder::formatEnumCallback(HACMDRIVERID driverId, LPACMFORMATDETAILS formatDetails, DWORD dwInstance, DWORD fdwSupport)
+	BOOL __stdcall Thunder::formatEnumCallback(HACMDRIVERID driverId, LPACMFORMATDETAILS formatDetails, DWORD_PTR dwInstance, DWORD fdwSupport)
 	{
 		if (formatDetails->pwfx->wFormatTag == WAVE_FORMAT_GSM610 &&
 			formatDetails->pwfx->nChannels == 1 &&

--- a/WaveSabreStandAlonePlayer/CMakeLists.txt
+++ b/WaveSabreStandAlonePlayer/CMakeLists.txt
@@ -4,12 +4,17 @@ target_link_libraries(WaveSabreStandAlonePlayer WaveSabrePlayerLib)
 if(MSVC)
 	target_compile_definitions(WaveSabreStandAlonePlayer PRIVATE _CRT_SECURE_NO_WARNINGS)
 
-	target_link_libraries(WaveSabreStandAlonePlayer
-		$<$<CONFIG:MinSizeRel>:${CMAKE_CURRENT_SOURCE_DIR}/msvcrt_old.lib>)
-	set_property(TARGET WaveSabreStandAlonePlayer APPEND_STRING PROPERTY LINK_FLAGS_MINSIZEREL
-		" /NODEFAULTLIB /SAFESEH:NO /MANIFEST:NO /LTCG /OPT:REF /OPT:ICF /DYNAMICBASE:NO")
+	if(${CMAKE_VS_PLATFORM_NAME} STREQUAL "Win32")
+		target_link_libraries(WaveSabreStandAlonePlayer
+			$<$<CONFIG:MinSizeRel>:${CMAKE_CURRENT_SOURCE_DIR}/msvcrt_old.lib>)
+		set_property(TARGET WaveSabreStandAlonePlayer APPEND_STRING PROPERTY LINK_FLAGS_MINSIZEREL
+			" /NODEFAULTLIB")
+	endif()
 
-	if(MSVC AND MSVC_VERSION GREATER 1900)
+	set_property(TARGET WaveSabreStandAlonePlayer APPEND_STRING PROPERTY LINK_FLAGS_MINSIZEREL
+		" /SAFESEH:NO /MANIFEST:NO /LTCG /OPT:REF /OPT:ICF /DYNAMICBASE:NO")
+
+	if(${CMAKE_VS_PLATFORM_NAME} STREQUAL "Win32" AND MSVC_VERSION GREATER 1900)
 		target_compile_definitions(WaveSabreStandAlonePlayer PRIVATE
 			$<$<CONFIG:MinSizeRel>:_NO_CRT_STDIO_INLINE>)
 	endif()


### PR DESCRIPTION
Here's a rework of #30, where I did a few changes:
- Split up the main commit into several commits
- Fixed a TODO
- Cleaned up the code a bit
- Fixed the indentation problens
- Added appveyor-builds of x64
- Rewored the size_t -> int patch to be smaller
- Wrote more comprehensive commit messages

I kept the authorship for the patches I copied verbatim. The other patches, I wrote on top.