### PR TITLE
cmake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ if(MSVC)
 	string(REPLACE "/EHsc" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
 endif()
 
-option(VSTSDK3_DIR "VSTSDK location" "./Vst3.x/")
+set(VSTSDK3_DIR "./Vst3.x/" CACHE PATH "VSTSDK location")
 
 # shared code
 add_subdirectory(WaveSabreCore)

--- a/Vsts/CMakeLists.txt
+++ b/Vsts/CMakeLists.txt
@@ -1,4 +1,4 @@
-option(VSTDIR "VST system directory")
+set(VSTDIR "" CACHE PATH "VST system directory")
 
 file(GLOB children RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*)
 foreach(child ${children})


### PR DESCRIPTION
Turns out, option is only really for boolean options. So let's use cached strings instead.