### PR TITLE
WaveSabreVstLib: explicitly build static lib

### DIFF
--- a/WaveSabreVstLib/CMakeLists.txt
+++ b/WaveSabreVstLib/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(WaveSabreVstLib
+add_library(WaveSabreVstLib STATIC
 	${VSTSDK3_DIR}/public.sdk/source/vst2.x/audioeffect.cpp
 	${VSTSDK3_DIR}/public.sdk/source/vst2.x/audioeffectx.cpp
 	${VSTSDK3_DIR}/public.sdk/source/vst2.x/vstplugmain.cpp


### PR DESCRIPTION
WaveSabreVstLib has to be built as a static lib, because it contains the
VST code that references createEffect, which is only defined in the
libraries that reference it. So let's make that explicit.

This allows us to build with -DBUILD_SHARED_LIBS=ON as well. Not that
it's a particularly useful switch, but it's nice to be robust.