### PR TITLE
WIP: Array malloc/free

### DIFF
--- a/WaveSabreCore/src/Adultery.cpp
+++ b/WaveSabreCore/src/Adultery.cpp
@@ -161,7 +161,7 @@ namespace WaveSabreCore
 					}
 				}
 
-				delete [] gmDls;
+				free(gmDls);
 			}
 			break;
 

--- a/WaveSabreCore/src/Adultery.cpp
+++ b/WaveSabreCore/src/Adultery.cpp
@@ -2,6 +2,7 @@
 #include <WaveSabreCore/Helpers.h>
 #include <WaveSabreCore/GmDls.h>
 
+#include <stdlib.h>
 #include <string.h>
 #include <math.h>
 
@@ -77,8 +78,7 @@ namespace WaveSabreCore
 
 	Adultery::~Adultery()
 	{
-		if (sampleData)
-			delete [] sampleData;
+		free(sampleData);
 	}
 
 	void Adultery::SetParam(int index, float value)
@@ -90,7 +90,7 @@ namespace WaveSabreCore
 
 			if (sampleData)
 			{
-				delete [] sampleData;
+				free(sampleData);
 				sampleData = nullptr;
 				sampleLength = 0;
 			}
@@ -141,7 +141,7 @@ namespace WaveSabreCore
 
 					// Data format is assumed to be mono 16-bit signed PCM
 					sampleLength = dataChunkSize / 2;
-					sampleData = new float[sampleLength];
+					sampleData = (float *)malloc(sizeof(float) * sampleLength);
 					for (int j = 0; j < sampleLength; j++)
 					{
 						auto sample = *((short *)wave);

--- a/WaveSabreCore/src/AllPass.cpp
+++ b/WaveSabreCore/src/AllPass.cpp
@@ -1,6 +1,7 @@
 #include <WaveSabreCore/AllPass.h>
 #include <WaveSabreCore/Helpers.h>
 
+#include <stdlib.h>
 #include <math.h>
 
 namespace WaveSabreCore
@@ -13,19 +14,19 @@ namespace WaveSabreCore
 
 	AllPass::~AllPass()
 	{
-		if (buffer) delete[] buffer;
+		free(buffer);
 	}
 
 	void AllPass::SetBufferSize(int size)
 	{
 		if (size < 1) size = 1;
 		bufferSize = size;
-		auto newBuffer = new float[size];
+		auto newBuffer = (float *)malloc(sizeof(float) * size);
 		for (int i = 0; i < size; i++) newBuffer[i] = 0.0f;
 		bufferIndex = 0;
 		auto oldBuffer = buffer;
 		buffer = newBuffer;
-		if (oldBuffer) delete[] oldBuffer;
+		free(oldBuffer);
 	}
 
 	void AllPass::SetFeedback(float value)

--- a/WaveSabreCore/src/Comb.cpp
+++ b/WaveSabreCore/src/Comb.cpp
@@ -1,6 +1,7 @@
 #include <WaveSabreCore/Comb.h>
 #include <WaveSabreCore/Helpers.h>
 
+#include <stdlib.h>
 #include <math.h>
 
 namespace WaveSabreCore
@@ -14,19 +15,19 @@ namespace WaveSabreCore
 
 	Comb::~Comb()
 	{
-		if (buffer) delete[] buffer;
+		free(buffer);
 	}
 
 	void Comb::SetBufferSize(int size)
 	{
 		if (size < 1) size = 1;
 		bufferSize = size;
-		auto newBuffer = new float[size];
+		auto newBuffer = (float *)malloc(sizeof(float) * size);
 		for (int i = 0; i < size; i++) newBuffer[i] = 0.0f;
 		bufferIndex = 0;
 		auto oldBuffer = buffer;
 		buffer = newBuffer;
-		if (oldBuffer) delete[] oldBuffer;
+		free(oldBuffer);
 	}
 
 	void Comb::SetDamp(float val)

--- a/WaveSabreCore/src/DelayBuffer.cpp
+++ b/WaveSabreCore/src/DelayBuffer.cpp
@@ -1,6 +1,8 @@
 #include <WaveSabreCore/DelayBuffer.h>
 #include <WaveSabreCore/Helpers.h>
 
+#include <stdlib.h>
+
 namespace WaveSabreCore
 {
 	DelayBuffer::DelayBuffer(float lengthMs)
@@ -11,7 +13,7 @@ namespace WaveSabreCore
 
 	DelayBuffer::~DelayBuffer()
 	{
-		if (buffer) delete[] buffer;
+		free(buffer);
 	}
 
 	void DelayBuffer::SetLength(float lengthMs)
@@ -20,13 +22,13 @@ namespace WaveSabreCore
 		if (newLength < 1) newLength = 1;
 		if (newLength != length || !buffer)
 		{
-			auto newBuffer = new float[newLength];
+			auto newBuffer = (float *)malloc(sizeof(float) * newLength);
 			for (int i = 0; i < newLength; i++) newBuffer[i] = 0.0f;
 			currentPosition = 0;
 			auto oldBuffer = buffer;
 			buffer = newBuffer;
 			length = newLength;
-			if (oldBuffer) delete[] oldBuffer;
+			free(oldBuffer);
 		}
 	}
 

--- a/WaveSabreCore/src/Device.cpp
+++ b/WaveSabreCore/src/Device.cpp
@@ -1,6 +1,8 @@
 #include <WaveSabreCore/Device.h>
 #include <WaveSabreCore/Helpers.h>
 
+#include <stdlib.h>
+
 namespace WaveSabreCore
 {
 	Device::Device(int numParams)
@@ -11,7 +13,7 @@ namespace WaveSabreCore
 
 	Device::~Device()
 	{
-		if (chunkData) delete (char *)chunkData;
+		free(chunkData);
 	}
 
 	void Device::AllNotesOff() { }
@@ -53,7 +55,7 @@ namespace WaveSabreCore
 	int Device::GetChunk(void **data)
 	{
 		int chunkSize = numParams * sizeof(float) + sizeof(int);
-		if (!chunkData) chunkData = new char[chunkSize];
+		if (!chunkData) chunkData = (char *)malloc(chunkSize);
 
 		for (int i = 0; i < numParams; i++)
 			((float *)chunkData)[i] = GetParam(i);

--- a/WaveSabreCore/src/GmDls.cpp
+++ b/WaveSabreCore/src/GmDls.cpp
@@ -20,7 +20,7 @@ namespace WaveSabreCore
 		}
 
 		auto gmDlsFileSize = GetFileSize(gmDlsFile, NULL);
-		auto gmDls = new unsigned char[gmDlsFileSize];
+		auto gmDls = (unsigned char *)malloc(gmDlsFileSize);
 		unsigned int bytesRead;
 		ReadFile(gmDlsFile, gmDls, gmDlsFileSize, (LPDWORD)&bytesRead, NULL);
 		CloseHandle(gmDlsFile);

--- a/WaveSabreCore/src/ResampleBuffer.cpp
+++ b/WaveSabreCore/src/ResampleBuffer.cpp
@@ -1,5 +1,6 @@
 #include <WaveSabreCore/ResampleBuffer.h>
 #include <WaveSabreCore/Helpers.h>
+#include <stdlib.h>
 #include <math.h>
 
 namespace WaveSabreCore
@@ -12,7 +13,7 @@ namespace WaveSabreCore
 
 	ResampleBuffer::~ResampleBuffer()
 	{
-		if (buffer) delete [] buffer;
+		free(buffer);
 	}
 
 	void ResampleBuffer::SetLength(float lengthMs)
@@ -26,13 +27,13 @@ namespace WaveSabreCore
 		if (samples < 1) samples = 1;
 		if (samples != length || !buffer)
 		{
-			auto newBuffer = new float[samples];
+			auto newBuffer = (float *)malloc(sizeof(float) * samples);
 			for (int i = 0; i < samples; i++) newBuffer[i] = 0.0f;
 			currentPosition = 0;
 			auto oldBuffer = buffer;
 			buffer = newBuffer;
 			length = samples;
-			if (oldBuffer) delete[] oldBuffer;
+			free(oldBuffer);
 		}
 	}
 

--- a/WaveSabrePlayerLib/src/PreRenderPlayer.cpp
+++ b/WaveSabrePlayerLib/src/PreRenderPlayer.cpp
@@ -12,7 +12,7 @@ namespace WaveSabrePlayerLib
 
 		const int stepSize = 100 * SongRenderer::NumChannels;
 		renderBufferSize = (int)((double)(sampleRate * SongRenderer::NumChannels) * songRenderer.GetLength()) / stepSize * stepSize;
-		renderBuffer = new SongRenderer::Sample[renderBufferSize];
+		renderBuffer = (SongRenderer::Sample *)malloc(sizeof(SongRenderer::Sample) * renderBufferSize);
 
 		int stepCounter = 0;
 
@@ -45,7 +45,7 @@ namespace WaveSabrePlayerLib
 		if (renderThread)
 			delete renderThread;
 
-		delete [] renderBuffer;
+		free(renderBuffer);
 	}
 
 	void PreRenderPlayer::Play()

--- a/WaveSabrePlayerLib/src/SongRenderer.Track.cpp
+++ b/WaveSabrePlayerLib/src/SongRenderer.Track.cpp
@@ -6,7 +6,7 @@ namespace WaveSabrePlayerLib
 {
 	SongRenderer::Track::Track(SongRenderer *songRenderer, SongRenderer::DeviceFactory factory)
 	{
-		for (int i = 0; i < numBuffers; i++) Buffers[i] = new float[songRenderer->sampleRate];
+		for (int i = 0; i < numBuffers; i++) Buffers[i] = (float *)malloc(sizeof(float) * songRenderer->sampleRate);
 
 		this->songRenderer = songRenderer;
 
@@ -15,7 +15,7 @@ namespace WaveSabrePlayerLib
 		NumReceives = songRenderer->readInt();
 		if (NumReceives)
 		{
-			Receives = new Receive[NumReceives];
+			Receives = (Receive *)malloc(sizeof(Receive) * NumReceives);
 			for (int i = 0; i < NumReceives; i++)
 			{
 				Receives[i].SendingTrackIndex = songRenderer->readInt();
@@ -27,7 +27,7 @@ namespace WaveSabrePlayerLib
 		numDevices = songRenderer->readInt();
 		if (numDevices)
 		{
-			devicesIndicies = new int[numDevices];
+			devicesIndicies = (int *)malloc(sizeof(int) * numDevices);
 			for (int i = 0; i < numDevices; i++)
 			{
 				devicesIndicies[i] = songRenderer->readInt();
@@ -39,7 +39,7 @@ namespace WaveSabrePlayerLib
 		numAutomations = songRenderer->readInt();
 		if (numAutomations)
 		{
-			automations = new Automation *[numAutomations];
+			automations = (Automation **)malloc(sizeof(Automation *) * numAutomations);
 			for (int i = 0; i < numAutomations; i++)
 			{
 				int deviceIndex = songRenderer->readInt();
@@ -54,20 +54,15 @@ namespace WaveSabrePlayerLib
 
 	SongRenderer::Track::~Track()
 	{
-		for (int i = 0; i < numBuffers; i++) delete [] Buffers[i];
-
-		if (NumReceives)
-			delete [] Receives;
+		for (int i = 0; i < numBuffers; i++) free(Buffers[i]);
+		free(Receives);
 		
-		if (numDevices)
-		{
-			delete[] devicesIndicies;
-		}
+		free(devicesIndicies);
 
 		if (numAutomations)
 		{
 			for (int i = 0; i < numAutomations; i++) delete automations[i];
-			delete [] automations;
+			free(automations);
 		}
 	}
 
@@ -123,7 +118,7 @@ namespace WaveSabrePlayerLib
 		this->device = device;
 		paramId = songRenderer->readInt();
 		numPoints = songRenderer->readInt();
-		points = new Point[numPoints];
+		points = (Point *)malloc(sizeof(Point) * numPoints);
 		int lastPointTime = 0;
 		for (int i = 0; i < numPoints; i++)
 		{
@@ -138,7 +133,7 @@ namespace WaveSabrePlayerLib
 
 	SongRenderer::Track::Automation::~Automation()
 	{
-		delete [] points;
+		free(points);
 	}
 
 	void SongRenderer::Track::Automation::Run(int numSamples)

--- a/WaveSabrePlayerLib/src/SongRenderer.cpp
+++ b/WaveSabrePlayerLib/src/SongRenderer.cpp
@@ -111,6 +111,7 @@ namespace WaveSabrePlayerLib
 
 		for (int i = 0; i < numRenderThreads; i++)
 			CloseHandle(renderThreadStartEvents[i]);
+		delete [] renderThreadStartEvents;
 		CloseHandle(renderDoneEvent);
 	}
 

--- a/WaveSabrePlayerLib/src/SongRenderer.cpp
+++ b/WaveSabrePlayerLib/src/SongRenderer.cpp
@@ -15,7 +15,7 @@ namespace WaveSabrePlayerLib
 		length = readDouble();
 
 		numDevices = readInt();
-		devices = new Device *[numDevices];
+		devices = (Device **)malloc(sizeof(Device *) * numDevices);
 		for (int i = 0; i < numDevices; i++)
 		{
 			devices[i] = song->factory((DeviceId)readByte());
@@ -27,13 +27,13 @@ namespace WaveSabrePlayerLib
 		}
 
 		numMidiLanes = readInt();
-		midiLanes = new MidiLane *[numMidiLanes];
+		midiLanes = (MidiLane **)malloc(sizeof(MidiLane *) * numMidiLanes);
 		for (int i = 0; i < numMidiLanes; i++)
 		{
 			midiLanes[i] = new MidiLane;
 			int numEvents = readInt();
 			midiLanes[i]->numEvents = numEvents;
-			midiLanes[i]->events = new Event[numEvents];
+			midiLanes[i]->events = (Event *)malloc(sizeof(Event) * numEvents);
 			for (int m = 0; m < numEvents; m++)
 			{
 				midiLanes[i]->events[m].TimeStamp = readInt();
@@ -54,8 +54,8 @@ namespace WaveSabrePlayerLib
 		}
 
 		numTracks = readInt();
-		tracks = new Track *[numTracks];
-		trackRenderStates = new TrackRenderState[numTracks];
+		tracks = (Track **)malloc(sizeof(Track *) * numTracks);
+		trackRenderStates = (TrackRenderState *)malloc(sizeof(TrackRenderState) * numTracks);
 		for (int i = 0; i < numTracks; i++)
 		{
 			tracks[i] = new Track(this, song->factory);
@@ -65,14 +65,14 @@ namespace WaveSabrePlayerLib
 		this->numRenderThreads = numRenderThreads;
 
 		renderThreadShutdown = false;
-		renderThreadStartEvents = new HANDLE[numRenderThreads];
+		renderThreadStartEvents = (HANDLE *)malloc(sizeof(HANDLE) * numRenderThreads);
 		for (int i = 0; i < numRenderThreads; i++)
 			renderThreadStartEvents[i] = CreateEvent(NULL, FALSE, FALSE, NULL);
 		renderDoneEvent = CreateEvent(NULL, FALSE, FALSE, NULL);
 
 		if (numRenderThreads > 1)
 		{
-			additionalRenderThreads = new HANDLE[numRenderThreads - 1];
+			additionalRenderThreads = (HANDLE *)malloc(sizeof(HANDLE) * (numRenderThreads - 1));
 			for (int i = 0; i < numRenderThreads - 1; i++)
 			{
 				auto renderThreadData = new RenderThreadData();
@@ -96,22 +96,22 @@ namespace WaveSabrePlayerLib
 			WaitForMultipleObjects(numRenderThreads - 1, additionalRenderThreads, TRUE, INFINITE);
 			for (int i = 0; i < numRenderThreads - 1; i++)
 				CloseHandle(additionalRenderThreads[i]);
-			delete [] additionalRenderThreads;
+			free(additionalRenderThreads);
 		}
 
 		for (int i = 0; i < numDevices; i++) delete devices[i];
-		delete [] devices;
+		free(devices);
 
 		for (int i = 0; i < numMidiLanes; i++) delete midiLanes[i];
-		delete [] midiLanes;
+		free(midiLanes);
 
 		for (int i = 0; i < numTracks; i++) delete tracks[i];
-		delete [] tracks;
-		delete [] trackRenderStates;
+		free(tracks);
+		free(trackRenderStates);
 
 		for (int i = 0; i < numRenderThreads; i++)
 			CloseHandle(renderThreadStartEvents[i]);
-		delete [] renderThreadStartEvents;
+		free(renderThreadStartEvents);
 		CloseHandle(renderDoneEvent);
 	}
 


### PR DESCRIPTION
Here's some old patches I had laying around to avoid using the array versions of new/delete instead of malloc/free that I wrote while trying to solve some CRT issues that I was able to work around in another way in the end.

But I recently realized that these save us 32 bytes, so perhaps it's worth it?

TBH, I suspect that a lot of these allocations can also be turned into constant allocations of reasonable bounds. For instance, I doubt we'll really need to be able to support more than maybe 8 threads for the renderer... probably even less. Such a limit could even be turned into a build-time constant if needed, if we'd want even more flexibility.

Anyway, I thought I'd post them, perhaps someone else has some thoughts here?

Note: these aren't properly tested yet, so please don't merge yet.