### PR TITLE
appveyor: also build MinSizeRel configuration

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,4 +16,5 @@ build_script:
   - cd build
   - cmake -DVSTSDK3_DIR="C:/tmp/VST3 SDK" ..
   - msbuild /v:minimal /nologo WaveSabre.sln
+  - msbuild /v:minimal /nologo /property:Configuration="MinSizeRel" WaveSabre.sln
   - cd ..


### PR DESCRIPTION
The MinSizeRel configuration is both quite important, and somewhat fragile. So we should make sure we don't regress the build here.

We could also split this into a build-matrix entry, to compile both in parallel, but I figured that at 2m per build vs two times 1m 15sec, it's not really worth dealing with... What do you think?