### PR TITLE
cmake: make building of VSTs optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,9 +13,13 @@ set(VSTSDK3_DIR "./Vst3.x/" CACHE PATH "VSTSDK location")
 # shared code
 add_subdirectory(WaveSabreCore)
 add_subdirectory(WaveSabrePlayerLib)
-add_subdirectory(WaveSabreVstLib)
 
 # binaries
 add_subdirectory(Tests/PlayerTest)
 add_subdirectory(WaveSabreStandAlonePlayer)
-add_subdirectory(Vsts)
+
+# VSTs
+if(VSTSDK3_DIR)
+	add_subdirectory(WaveSabreVstLib)
+	add_subdirectory(Vsts)
+endif()


### PR DESCRIPTION
If we set the VSTSDK3_DIR variable to NO, we can opt out of building the
VSTs alltogether.

This is useful in cases where a the VSTs and player are for different
targets, for instance different architectures or operating systems.