### PR TITLE
WIP: Make deprecated VSTs an opt-in

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,11 @@ endif()
 
 set(VSTSDK3_DIR "./Vst3.x/" CACHE PATH "VSTSDK location")
 
+option(BUILD_DEPRECATED "Build deprecated VSTs" OFF)
+if(BUILD_DEPRECATED)
+	add_compile_definitions(BUILD_DEPRECATED)
+endif()
+
 # shared code
 add_subdirectory(WaveSabreCore)
 add_subdirectory(WaveSabrePlayerLib)

--- a/Vsts/CMakeLists.txt
+++ b/Vsts/CMakeLists.txt
@@ -1,6 +1,11 @@
 set(VSTDIR "" CACHE PATH "VST system directory")
 
 file(GLOB children RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*)
+
+if(NOT BUILD_DEPRECATED)
+	list(REMOVE_ITEM children "Thunder")
+endif()
+
 foreach(child ${children})
 	if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${child})
 		file(GLOB sources ${CMAKE_CURRENT_SOURCE_DIR}/${child}/*.h)

--- a/WaveSabreCore/CMakeLists.txt
+++ b/WaveSabreCore/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(WaveSabreCore
+set(WaveSabreCore_SOURCES
 	include/WaveSabreCore/Adultery.h
 	include/WaveSabreCore/AllPass.h
 	include/WaveSabreCore/AllPassDelay.h
@@ -24,7 +24,6 @@ add_library(WaveSabreCore
 	include/WaveSabreCore/Specimen.h
 	include/WaveSabreCore/StateVariableFilter.h
 	include/WaveSabreCore/SynthDevice.h
-	include/WaveSabreCore/Thunder.h
 	include/WaveSabreCore/Twister.h
 	src/Adultery.cpp
 	src/AllPass.cpp
@@ -51,8 +50,15 @@ add_library(WaveSabreCore
 	src/Specimen.cpp
 	src/StateVariableFilter.cpp
 	src/SynthDevice.cpp
-	src/Thunder.cpp
 	src/Twister.cpp)
+
+if(BUILD_DEPRECATED)
+	list(APPEND WaveSabreCore_SOURCES
+		include/WaveSabreCore/Thunder.h
+		src/Thunder.cpp)
+endif()
+
+add_library(WaveSabreCore ${WaveSabreCore_SOURCES})
 
 target_link_libraries(WaveSabreCore Msacm32.lib)
 target_include_directories(WaveSabreCore PUBLIC include)

--- a/WaveSabrePlayerLib/include/WaveSabrePlayerLib/SongRenderer.h
+++ b/WaveSabrePlayerLib/include/WaveSabrePlayerLib/SongRenderer.h
@@ -14,7 +14,9 @@ namespace WaveSabrePlayerLib
 		{
 			Falcon,
 			Slaughter,
+#ifdef BUILD_DEPRECATED
 			Thunder,
+#endif
 			Scissor,
 			Leveller,
 			Crusher,

--- a/WaveSabreStandAlonePlayer/main.cpp
+++ b/WaveSabreStandAlonePlayer/main.cpp
@@ -10,7 +10,9 @@ WaveSabreCore::Device *SongFactory(SongRenderer::DeviceId id)
 	{
 	case SongRenderer::DeviceId::Falcon: return new WaveSabreCore::Falcon();
 	case SongRenderer::DeviceId::Slaughter: return new WaveSabreCore::Slaughter();
+#ifdef BUILD_DEPRECATED
 	case SongRenderer::DeviceId::Thunder: return new WaveSabreCore::Thunder();
+#endif
 	case SongRenderer::DeviceId::Scissor: return new WaveSabreCore::Scissor();
 	case SongRenderer::DeviceId::Leveller: return new WaveSabreCore::Leveller();
 	case SongRenderer::DeviceId::Crusher: return new WaveSabreCore::Crusher();


### PR DESCRIPTION
Thunder is deprecated, so there's no point in building it by default.

Marked as WIP because:
1. It's not properly tested yet
2. We should probably define this for a CI build to prevent accidental breakage