### PR TITLE
fix -fpermissive error/warning on gcc/clang

### DIFF
--- a/WaveSabreCore/include/WaveSabreCore/Adultery.h
+++ b/WaveSabreCore/include/WaveSabreCore/Adultery.h
@@ -65,7 +65,7 @@ namespace WaveSabreCore
 		{
 		public:
 			AdulteryVoice(Adultery *adultery);
-			virtual WaveSabreCore::SynthDevice *SynthDevice() const;
+			virtual WaveSabreCore::SynthDevice *GetSynthDevice() const;
 
 			virtual void Run(double songPosition, float **outputs, int numSamples);
 

--- a/WaveSabreCore/include/WaveSabreCore/Falcon.h
+++ b/WaveSabreCore/include/WaveSabreCore/Falcon.h
@@ -66,7 +66,7 @@ namespace WaveSabreCore
 		{
 		public:
 			FalconVoice(Falcon *falcon);
-			virtual WaveSabreCore::SynthDevice *SynthDevice() const;
+			virtual WaveSabreCore::SynthDevice *GetSynthDevice() const;
 
 			virtual void Run(double songPosition, float **outputs, int numSamples);
 

--- a/WaveSabreCore/include/WaveSabreCore/Slaughter.h
+++ b/WaveSabreCore/include/WaveSabreCore/Slaughter.h
@@ -80,7 +80,7 @@ namespace WaveSabreCore
 		{
 		public:
 			SlaughterVoice(Slaughter *slaughter);
-			virtual WaveSabreCore::SynthDevice *SynthDevice() const;
+			virtual WaveSabreCore::SynthDevice *GetSynthDevice() const;
 
 			virtual void Run(double songPosition, float **outputs, int numSamples);
 

--- a/WaveSabreCore/include/WaveSabreCore/Specimen.h
+++ b/WaveSabreCore/include/WaveSabreCore/Specimen.h
@@ -77,7 +77,7 @@ namespace WaveSabreCore
 		{
 		public:
 			SpecimenVoice(Specimen *thunder);
-			virtual WaveSabreCore::SynthDevice *SynthDevice() const;
+			virtual WaveSabreCore::SynthDevice *GetSynthDevice() const;
 
 			virtual void Run(double songPosition, float **outputs, int numSamples);
 

--- a/WaveSabreCore/include/WaveSabreCore/SynthDevice.h
+++ b/WaveSabreCore/include/WaveSabreCore/SynthDevice.h
@@ -48,7 +48,7 @@ namespace WaveSabreCore
 			Voice();
 			virtual ~Voice();
 
-			virtual SynthDevice *SynthDevice() const = 0;
+			virtual SynthDevice *GetSynthDevice() const = 0;
 
 			virtual void Run(double songPosition, float **outputs, int numSamples) = 0;
 

--- a/WaveSabreCore/include/WaveSabreCore/Thunder.h
+++ b/WaveSabreCore/include/WaveSabreCore/Thunder.h
@@ -31,7 +31,7 @@ namespace WaveSabreCore
 		{
 		public:
 			ThunderVoice(Thunder *thunder);
-			virtual WaveSabreCore::SynthDevice *SynthDevice() const;
+			virtual WaveSabreCore::SynthDevice *GetSynthDevice() const;
 
 			virtual void Run(double songPosition, float **outputs, int numSamples);
 

--- a/WaveSabreCore/src/Adultery.cpp
+++ b/WaveSabreCore/src/Adultery.cpp
@@ -253,7 +253,7 @@ namespace WaveSabreCore
 		this->adultery = adultery;
 	}
 
-	SynthDevice *Adultery::AdulteryVoice::SynthDevice() const
+	SynthDevice *Adultery::AdulteryVoice::GetSynthDevice() const
 	{
 		return adultery;
 	}

--- a/WaveSabreCore/src/Falcon.cpp
+++ b/WaveSabreCore/src/Falcon.cpp
@@ -145,7 +145,7 @@ namespace WaveSabreCore
 		this->falcon = falcon;
 	}
 
-	SynthDevice *Falcon::FalconVoice::SynthDevice() const
+	SynthDevice *Falcon::FalconVoice::GetSynthDevice() const
 	{
 		return falcon;
 	}

--- a/WaveSabreCore/src/Slaughter.cpp
+++ b/WaveSabreCore/src/Slaughter.cpp
@@ -176,7 +176,7 @@ namespace WaveSabreCore
 		osc1.Integral = osc2.Integral = osc3.Integral = 0.0;
 	}
 
-	SynthDevice *Slaughter::SlaughterVoice::SynthDevice() const
+	SynthDevice *Slaughter::SlaughterVoice::GetSynthDevice() const
 	{
 		return slaughter;
 	}

--- a/WaveSabreCore/src/Specimen.cpp
+++ b/WaveSabreCore/src/Specimen.cpp
@@ -289,7 +289,7 @@ namespace WaveSabreCore
 		this->specimen = specimen;
 	}
 
-	SynthDevice *Specimen::SpecimenVoice::SynthDevice() const
+	SynthDevice *Specimen::SpecimenVoice::GetSynthDevice() const
 	{
 		return specimen;
 	}

--- a/WaveSabreCore/src/SynthDevice.cpp
+++ b/WaveSabreCore/src/SynthDevice.cpp
@@ -249,7 +249,7 @@ namespace WaveSabreCore
 		slideActive = true;
 		destinationNote = note;
 		
-		double slideTime = 10.f * Helpers::Pow(this->SynthDevice()->Slide,4.0);
+		double slideTime = 10.f * Helpers::Pow(this->GetSynthDevice()->Slide,4.0);
 		slideDelta = ((double)note - currentNote) / (Helpers::CurrentSampleRate * slideTime);
 		slideSamples = (int)(Helpers::CurrentSampleRate * slideTime);
 	}

--- a/WaveSabreCore/src/Thunder.cpp
+++ b/WaveSabreCore/src/Thunder.cpp
@@ -120,7 +120,7 @@ namespace WaveSabreCore
 		this->thunder = thunder;
 	}
 
-	SynthDevice *Thunder::ThunderVoice::SynthDevice() const
+	SynthDevice *Thunder::ThunderVoice::GetSynthDevice() const
 	{
 		return thunder;
 	}


### PR DESCRIPTION
The error (which gets turned into a warning when specifying `-fpermissive`) looks like this:

```
WaveSabreCore/include/WaveSabreCore/SynthDevice.h:51:25: warning: declaration of ‘virtual WaveSabreCore::SynthDevice* WaveSabreCore::SynthDevice::Voice::SynthDevice() const’ changes meaning of ‘SynthDevice’ [-fpermissive]
   51 |    virtual SynthDevice *SynthDevice() const = 0;
      |                         ^~~~~~~~~~~
WaveSabreCore/include/WaveSabreCore/SynthDevice.h:15:2: note: ‘SynthDevice’ declared here as ‘class WaveSabreCore::SynthDevice WaveSabreCore::SynthDevice::SynthDevice’
   15 |  {
      |  ^
```