### PR TITLE
SongRenderer: plug memory-leak

### DIFF
--- a/WaveSabrePlayerLib/src/SongRenderer.cpp
+++ b/WaveSabrePlayerLib/src/SongRenderer.cpp
@@ -102,7 +102,10 @@ namespace WaveSabrePlayerLib
 		for (int i = 0; i < numDevices; i++) delete devices[i];
 		delete [] devices;
 
-		for (int i = 0; i < numMidiLanes; i++) delete midiLanes[i];
+		for (int i = 0; i < numMidiLanes; i++) {
+			delete midiLanes[i]->events;
+			delete midiLanes[i];
+		}
 		delete [] midiLanes;
 
 		for (int i = 0; i < numTracks; i++) delete tracks[i];


### PR DESCRIPTION
Just a drive-by fix; noticed this while rebasing some old patches; we're currently leaking the events-array. It's not a big deal, but we might as well plug it.