### PR TITLE
cmake: specify correct default-path to VSTSDK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ if(MSVC)
 	string(REPLACE "/EHsc" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
 endif()
 
-set(VSTSDK3_DIR "./Vst3.x/" CACHE PATH "VSTSDK location")
+set(VSTSDK3_DIR "${CMAKE_SOURCE_DIR}/Vst3.x/" CACHE PATH "VSTSDK location")
 
 # shared code
 add_subdirectory(MSVCRT)


### PR DESCRIPTION
If this path is relative, it needs to also deal with the location in the
tree relative to the root. Let's make things easier, and just make it
absolute instead.