### PR TITLE
WIP: cmake: default to x86 builds on newer VS versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ if(MSVC)
 	string(REPLACE "/EHsc" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
 endif()
 
+set(CMAKE_VS_PLATFORM_NAME_DEFAULT "Win32")
 set(VSTSDK3_DIR "${CMAKE_SOURCE_DIR}/Vst3.x/" CACHE PATH "VSTSDK location")
 
 # shared code


### PR DESCRIPTION
WaveSabre is mainly an x86 project, and up until CMake 3.14 it always
picked the Win32 target for MSVC projects. But in version 3.14 this
changed when the VS 2019 generator was added, which picks x64 by default
on x64 machines.

So let's override that, so we compile x86 code by default. It's what
most users are going to want.