### PR TITLE
Remove biquad filter zero clamp

### DIFF
--- a/WaveSabreCore/src/BiquadFilter.cpp
+++ b/WaveSabreCore/src/BiquadFilter.cpp
@@ -75,9 +75,6 @@ namespace WaveSabreCore
 
 		lastLastInput = lastInput;
 		lastInput = input;
-
-		if (fabsf(lastOutput) <= .0000001f) lastOutput = 0.0f;
-
 		lastLastOutput = lastOutput;
 		lastOutput = output;
 


### PR DESCRIPTION
The clamping of one of the delay samples causes a discontinuity in the filter feedback path that results in self oscillation even while the input is zero. The self oscillation is very quiet, somewhere around -70dB (possibly more at very low cutoffs and large Q values), but in practice can become easily audible if the signal path after the biquad contains further processing, especially saturation that boosts the signal. It's also especially noticeable with Leveller, as it contains five individual biquad stages. Removing the clamp doesn't have any other audible adverse side effects based on my testing. (Of course it also makes for a tiny improvement in both size and performance as well.)