### PR TITLE
Converter: Fix incorrect comment for automation de-dupe routine

### DIFF
--- a/WaveSabreConvert/Song.cs
+++ b/WaveSabreConvert/Song.cs
@@ -230,7 +230,7 @@ namespace WaveSabreConvert
         }
 
         // looks for automation points where three in a row are the same value
-        // then removes the middle point, increasing the time stamp for the first one
+        // then removes the point on the right, adjusting the middle point's time stamp to take its place
         private int DedupeAutomations()
         {
             var dupeCount = 0;


### PR DESCRIPTION
This may seem trivial/benign, but I'm trying to make sure all of our test refs are up-to-date (#63), and it's a bigger job than I'd like, so I'm hoping to grasp the existing code enough to just trust it and update the refs more or less automatically. This comment ended up throwing me for a loop more than I'd like to admit!

The comment now matches the current behavior, which should produce correct results. The previous description would turn this:

```
     v redundant point
   ._._.
_./     \._
```

Into this:

```
     v adjusted point; the point that used to be here is removed
     ._.
_.~~~   \._
```

Which is clearly wrong. Instead, we should (and do) get this:

```
       v adjusted point; the point that used to be here is removed
   .___.
_./     \._
```