### PR TITLE
Factor out sample loading/management from Thunder/Specimen

### DIFF
--- a/WaveSabreCore/CMakeLists.txt
+++ b/WaveSabreCore/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(WaveSabreCore
 	include/WaveSabreCore/Envelope.h
 	include/WaveSabreCore/Falcon.h
 	include/WaveSabreCore/GmDls.h
+	include/WaveSabreCore/GsmSample.h
 	include/WaveSabreCore/Helpers.h
 	include/WaveSabreCore/Leveller.h
 	include/WaveSabreCore/MxcsrFlagGuard.h
@@ -40,6 +41,7 @@ add_library(WaveSabreCore
 	src/Envelope.cpp
 	src/Falcon.cpp
 	src/GmDls.cpp
+	src/GsmSample.cpp
 	src/Helpers.cpp
 	src/Leveller.cpp
 	src/MxcsrFlagGuard.cpp

--- a/WaveSabreCore/include/WaveSabreCore/GsmSample.h
+++ b/WaveSabreCore/include/WaveSabreCore/GsmSample.h
@@ -1,0 +1,39 @@
+#ifndef __WAVESABRECORE_GSMSAMPLE_H__
+#define __WAVESABRECORE_GSMSAMPLE_H__
+
+#include "Helpers.h"
+
+#include <Windows.h>
+
+#ifdef UNICODE
+#define _UNICODE
+#endif
+
+#include <mmreg.h>
+#include <MSAcm.h>
+
+namespace WaveSabreCore
+{
+	class GsmSample
+	{
+	public:
+		GsmSample(char *data, int compressedSize, int uncompressedSize, WAVEFORMATEX *waveFormat);
+		~GsmSample();
+
+		char *WaveFormatData;
+		int CompressedSize, UncompressedSize;
+
+		char *CompressedData;
+		float *SampleData;
+
+		int SampleLength;
+
+	private:
+		static BOOL __stdcall driverEnumCallback(HACMDRIVERID driverId, DWORD_PTR dwInstance, DWORD fdwSupport);
+		static BOOL __stdcall formatEnumCallback(HACMDRIVERID driverId, LPACMFORMATDETAILS formatDetails, DWORD_PTR dwInstance, DWORD fdwSupport);
+
+		static HACMDRIVERID driverId;
+	};
+}
+
+#endif

--- a/WaveSabreCore/include/WaveSabreCore/Specimen.h
+++ b/WaveSabreCore/include/WaveSabreCore/Specimen.h
@@ -5,14 +5,7 @@
 #include "Envelope.h"
 #include "StateVariableFilter.h"
 #include "SamplePlayer.h"
-
-#include <Windows.h>
-#include <mmreg.h>
-
-#ifdef UNICODE
-#define _UNICODE
-#endif
-#include <MSAcm.h>
+#include "GsmSample.h"
 
 namespace WaveSabreCore
 {
@@ -70,7 +63,7 @@ namespace WaveSabreCore
 		virtual void SetChunk(void *data, int size);
 		virtual int GetChunk(void **data);
 
-		void LoadSample(char *data, int compressedSize, int uncompressedSize, WAVEFORMATEX *waveFormat);
+		void LoadSample(char *compressedDataPtr, int compressedSize, int uncompressedSize, WAVEFORMATEX *waveFormatPtr);
 
 	private:
 		class SpecimenVoice : public Voice
@@ -99,18 +92,9 @@ namespace WaveSabreCore
 			float velocity;
 		};
 
-		static BOOL __stdcall driverEnumCallback(HACMDRIVERID driverId, DWORD_PTR dwInstance, DWORD fdwSupport);
-		static BOOL __stdcall formatEnumCallback(HACMDRIVERID driverId, LPACMFORMATDETAILS formatDetails, DWORD_PTR dwInstance, DWORD fdwSupport);
-
-		static HACMDRIVERID driverId;
-
 		char *chunkData;
 
-		char *waveFormatData;
-		int compressedSize, uncompressedSize;
-
-		char *compressedData;
-		float *sampleData;
+		GsmSample* sample;
 
 		float ampAttack, ampDecay, ampSustain, ampRelease;
 		float sampleStart;
@@ -121,7 +105,6 @@ namespace WaveSabreCore
 
 		InterpolationMode interpolationMode;
 
-		int sampleLength;
 		int sampleLoopStart, sampleLoopLength;
 		float coarseTune, fineTune;
 		float masterLevel;

--- a/WaveSabreCore/include/WaveSabreCore/Thunder.h
+++ b/WaveSabreCore/include/WaveSabreCore/Thunder.h
@@ -2,14 +2,7 @@
 #define __WAVESABRECORE_THUNDER_H__
 
 #include "SynthDevice.h"
-
-#include <Windows.h>
-#include <mmreg.h>
-
-#ifdef UNICODE
-#define _UNICODE
-#endif
-#include <MSAcm.h>
+#include "GsmSample.h"
 
 namespace WaveSabreCore
 {
@@ -24,7 +17,7 @@ namespace WaveSabreCore
 		virtual void SetChunk(void *data, int size);
 		virtual int GetChunk(void **data);
 
-		void LoadSample(char *data, int compressedSize, int uncompressedSize, WAVEFORMATEX *waveFormat);
+		void LoadSample(char *compressedDataPtr, int compressedSize, int uncompressedSize, WAVEFORMATEX *waveFormatPtr);
 
 	private:
 		class ThunderVoice : public Voice
@@ -43,20 +36,9 @@ namespace WaveSabreCore
 			int samplePos;
 		};
 
-		static BOOL __stdcall driverEnumCallback(HACMDRIVERID driverId, DWORD_PTR dwInstance, DWORD fdwSupport);
-		static BOOL __stdcall formatEnumCallback(HACMDRIVERID driverId, LPACMFORMATDETAILS formatDetails, DWORD_PTR dwInstance, DWORD fdwSupport);
-
-		static HACMDRIVERID driverId;
-
 		char *chunkData;
 
-		char *waveFormatData;
-		int compressedSize, uncompressedSize;
-
-		char *compressedData;
-		float *sampleData;
-
-		int sampleLength;
+		GsmSample *sample;
 	};
 }
 

--- a/WaveSabreCore/src/GsmSample.cpp
+++ b/WaveSabreCore/src/GsmSample.cpp
@@ -1,0 +1,102 @@
+#include <WaveSabreCore/GsmSample.h>
+
+#include <string.h>
+
+namespace WaveSabreCore
+{
+	GsmSample::GsmSample(char *data, int compressedSize, int uncompressedSize, WAVEFORMATEX *waveFormat)
+		: CompressedSize(compressedSize)
+		, UncompressedSize(uncompressedSize)
+	{
+		WaveFormatData = new char[sizeof(WAVEFORMATEX) + waveFormat->cbSize];
+		memcpy(WaveFormatData, waveFormat, sizeof(WAVEFORMATEX) + waveFormat->cbSize);
+		CompressedData = new char[compressedSize];
+		memcpy(CompressedData, data, compressedSize);
+
+		acmDriverEnum(driverEnumCallback, NULL, NULL);
+		HACMDRIVER driver = NULL;
+		acmDriverOpen(&driver, driverId, 0);
+
+		WAVEFORMATEX dstWaveFormat =
+		{
+			WAVE_FORMAT_PCM,
+			1,
+			waveFormat->nSamplesPerSec,
+			waveFormat->nSamplesPerSec * 2,
+			sizeof(short),
+			sizeof(short) * 8,
+			0
+		};
+
+		HACMSTREAM stream = NULL;
+		acmStreamOpen(&stream, driver, waveFormat, &dstWaveFormat, NULL, NULL, NULL, ACM_STREAMOPENF_NONREALTIME);
+
+		ACMSTREAMHEADER streamHeader;
+		memset(&streamHeader, 0, sizeof(ACMSTREAMHEADER));
+		streamHeader.cbStruct = sizeof(ACMSTREAMHEADER);
+		streamHeader.pbSrc = (LPBYTE)CompressedData;
+		streamHeader.cbSrcLength = compressedSize;
+		auto uncompressedData = new short[uncompressedSize * 2];
+		streamHeader.pbDst = (LPBYTE)uncompressedData;
+		streamHeader.cbDstLength = uncompressedSize * 2;
+		acmStreamPrepareHeader(stream, &streamHeader, 0);
+
+		acmStreamConvert(stream, &streamHeader, 0);
+
+		acmStreamClose(stream, 0);
+		acmDriverClose(driver, 0);
+
+		SampleLength = streamHeader.cbDstLengthUsed / sizeof(short);
+		SampleData = new float[SampleLength];
+		for (int i = 0; i < SampleLength; i++)
+			SampleData[i] = (float)((double)uncompressedData[i] / 32768.0);
+
+		delete [] uncompressedData;
+	}
+
+	GsmSample::~GsmSample()
+	{
+		delete [] WaveFormatData;
+		delete [] CompressedData;
+		delete [] SampleData;
+	}
+
+	HACMDRIVERID GsmSample::driverId = NULL;
+
+	BOOL __stdcall GsmSample::driverEnumCallback(HACMDRIVERID driverId, DWORD_PTR dwInstance, DWORD fdwSupport)
+	{
+		if (GsmSample::driverId) return 1;
+
+		HACMDRIVER driver = NULL;
+		acmDriverOpen(&driver, driverId, 0);
+
+		int waveFormatSize = 0;
+		acmMetrics(NULL, ACM_METRIC_MAX_SIZE_FORMAT, &waveFormatSize);
+		auto waveFormat = (WAVEFORMATEX *)(new char[waveFormatSize]);
+		memset(waveFormat, 0, waveFormatSize);
+		ACMFORMATDETAILS formatDetails;
+		memset(&formatDetails, 0, sizeof(formatDetails));
+		formatDetails.cbStruct = sizeof(formatDetails);
+		formatDetails.pwfx = waveFormat;
+		formatDetails.cbwfx = waveFormatSize;
+		formatDetails.dwFormatTag = WAVE_FORMAT_UNKNOWN;
+		acmFormatEnum(driver, &formatDetails, formatEnumCallback, NULL, NULL);
+
+		delete [] (char *)waveFormat;
+
+		acmDriverClose(driver, 0);
+
+		return 1;
+	}
+
+	BOOL __stdcall GsmSample::formatEnumCallback(HACMDRIVERID driverId, LPACMFORMATDETAILS formatDetails, DWORD_PTR dwInstance, DWORD fdwSupport)
+	{
+		if (formatDetails->pwfx->wFormatTag == WAVE_FORMAT_GSM610 &&
+			formatDetails->pwfx->nChannels == 1 &&
+			formatDetails->pwfx->nSamplesPerSec == 44100)
+		{
+			GsmSample::driverId = driverId;
+		}
+		return 1;
+	}
+}

--- a/WaveSabreCore/src/Specimen.cpp
+++ b/WaveSabreCore/src/Specimen.cpp
@@ -8,7 +8,7 @@ namespace WaveSabreCore
 	HACMDRIVERID Specimen::driverId = NULL;
 
 	Specimen::Specimen()
-		: SynthDevice(0)
+		: SynthDevice((int)ParamIndices::NumParams)
 	{
 		for (int i = 0; i < maxVoices; i++) voices[i] = new SpecimenVoice(this);
 

--- a/WaveSabreCore/src/Thunder.cpp
+++ b/WaveSabreCore/src/Thunder.cpp
@@ -5,29 +5,19 @@
 
 namespace WaveSabreCore
 {
-	HACMDRIVERID Thunder::driverId = NULL;
-
 	Thunder::Thunder()
 		: SynthDevice(0)
+		, sample(nullptr)
 	{
 		for (int i = 0; i < maxVoices; i++) voices[i] = new ThunderVoice(this);
 
 		chunkData = nullptr;
-
-		waveFormatData = nullptr;
-		compressedSize = uncompressedSize = 0;
-		compressedData = nullptr;
-		sampleData = nullptr;
-
-		sampleLength = 0;
 	}
 
 	Thunder::~Thunder()
 	{
 		if (chunkData) delete [] chunkData;
-		if (waveFormatData) delete [] waveFormatData;
-		if (compressedData) delete [] compressedData;
-		if (sampleData) delete [] sampleData;
+		if (sample) delete sample;
 	}
 
 	typedef struct
@@ -47,72 +37,26 @@ namespace WaveSabreCore
 
 	int Thunder::GetChunk(void **data)
 	{
-		if (!compressedData) return 0;
+		if (!sample) return 0;
 		ChunkHeader h;
-		h.CompressedSize = compressedSize;
-		h.UncompressedSize = uncompressedSize;
+		h.CompressedSize = sample->CompressedSize;
+		h.UncompressedSize = sample->UncompressedSize;
 		if (chunkData) delete [] chunkData;
-		int chunkSize = sizeof(ChunkHeader) + sizeof(WAVEFORMATEX) + ((WAVEFORMATEX *)waveFormatData)->cbSize + compressedSize + sizeof(int);
+		int chunkSize = sizeof(ChunkHeader) + sizeof(WAVEFORMATEX) + ((WAVEFORMATEX *)sample->WaveFormatData)->cbSize + sample->CompressedSize + sizeof(int);
 		chunkData = new char[chunkSize];
 		memcpy(chunkData, &h, sizeof(ChunkHeader));
-		memcpy(chunkData + sizeof(ChunkHeader), waveFormatData, sizeof(WAVEFORMATEX) + ((WAVEFORMATEX *)waveFormatData)->cbSize);
-		memcpy(chunkData + sizeof(ChunkHeader) + sizeof(WAVEFORMATEX) + ((WAVEFORMATEX *)waveFormatData)->cbSize, compressedData, compressedSize);
+		memcpy(chunkData + sizeof(ChunkHeader), sample->WaveFormatData, sizeof(WAVEFORMATEX) + ((WAVEFORMATEX *)sample->WaveFormatData)->cbSize);
+		memcpy(chunkData + sizeof(ChunkHeader) + sizeof(WAVEFORMATEX) + ((WAVEFORMATEX *)sample->WaveFormatData)->cbSize, sample->CompressedData, sample->CompressedSize);
 		*(int *)(chunkData + chunkSize - sizeof(int)) = chunkSize;
 		*data = chunkData;
 		return chunkSize;
 	}
 
-	void Thunder::LoadSample(char *data, int compressedSize, int uncompressedSize, WAVEFORMATEX *waveFormat)
+	void Thunder::LoadSample(char *compressedDataPtr, int compressedSize, int uncompressedSize, WAVEFORMATEX *waveFormatPtr)
 	{
-		this->compressedSize = compressedSize;
-		this->uncompressedSize = uncompressedSize;
+		if (sample) delete sample;
 
-		if (waveFormatData) delete [] waveFormatData;
-		waveFormatData = new char[sizeof(WAVEFORMATEX) + waveFormat->cbSize];
-		memcpy(waveFormatData, waveFormat, sizeof(WAVEFORMATEX) + waveFormat->cbSize);
-		if (compressedData) delete [] compressedData;
-		compressedData = new char[compressedSize];
-		memcpy(compressedData, data, compressedSize);
-
-		acmDriverEnum(driverEnumCallback, NULL, NULL);
-		HACMDRIVER driver = NULL;
-		acmDriverOpen(&driver, driverId, 0);
-
-		WAVEFORMATEX dstWaveFormat =
-		{
-			WAVE_FORMAT_PCM,
-			1,
-			waveFormat->nSamplesPerSec,
-			waveFormat->nSamplesPerSec * 2,
-			sizeof(short),
-			sizeof(short) * 8,
-			0
-		};
-
-		HACMSTREAM stream = NULL;
-		acmStreamOpen(&stream, driver, waveFormat, &dstWaveFormat, NULL, NULL, NULL, ACM_STREAMOPENF_NONREALTIME);
-
-		ACMSTREAMHEADER streamHeader;
-		memset(&streamHeader, 0, sizeof(ACMSTREAMHEADER));
-		streamHeader.cbStruct = sizeof(ACMSTREAMHEADER);
-		streamHeader.pbSrc = (LPBYTE)compressedData;
-		streamHeader.cbSrcLength = compressedSize;
-		auto uncompressedData = new short[uncompressedSize * 2];
-		streamHeader.pbDst = (LPBYTE)uncompressedData;
-		streamHeader.cbDstLength = uncompressedSize * 2;
-		acmStreamPrepareHeader(stream, &streamHeader, 0);
-
-		acmStreamConvert(stream, &streamHeader, 0);
-		
-		acmStreamClose(stream, 0);
-		acmDriverClose(driver, 0);
-
-		sampleLength = streamHeader.cbDstLengthUsed / sizeof(short);
-		if (sampleData) delete [] sampleData;
-		sampleData = new float[sampleLength];
-		for (int i = 0; i < sampleLength; i++) sampleData[i] = (float)((double)uncompressedData[i] / 32768.0);
-
-		delete [] uncompressedData;
+		sample = new GsmSample(compressedDataPtr, compressedSize, uncompressedSize, waveFormatPtr);
 	}
 
 	Thunder::ThunderVoice::ThunderVoice(Thunder *thunder)
@@ -129,12 +73,12 @@ namespace WaveSabreCore
 	{
 		for (int i = 0; i < numSamples; i++)
 		{
-			if (samplePos >= thunder->sampleLength)
+			if (samplePos >= thunder->sample->SampleLength)
 			{
 				IsOn = false;
 				break;
 			}
-			float sample = thunder->sampleData[samplePos];
+			float sample = thunder->sample->SampleData[samplePos];
 			outputs[0][i] += sample;
 			outputs[1][i] += sample;
 			samplePos++;
@@ -145,42 +89,5 @@ namespace WaveSabreCore
 	{
 		Voice::NoteOn(note, velocity, detune, pan);
 		samplePos = 0;
-	}
-
-	BOOL __stdcall Thunder::driverEnumCallback(HACMDRIVERID driverId, DWORD_PTR dwInstance, DWORD fdwSupport)
-	{
-		if (Thunder::driverId) return 1;
-
-		HACMDRIVER driver = NULL;
-		acmDriverOpen(&driver, driverId, 0);
-
-		int waveFormatSize = 0;
-		acmMetrics(NULL, ACM_METRIC_MAX_SIZE_FORMAT, &waveFormatSize);
-		auto waveFormat = (WAVEFORMATEX *)(new char[waveFormatSize]);
-		memset(waveFormat, 0, waveFormatSize);
-		ACMFORMATDETAILS formatDetails;
-		memset(&formatDetails, 0, sizeof(formatDetails));
-		formatDetails.cbStruct = sizeof(formatDetails);
-		formatDetails.pwfx = waveFormat;
-		formatDetails.cbwfx = waveFormatSize;
-		formatDetails.dwFormatTag = WAVE_FORMAT_UNKNOWN;
-		acmFormatEnum(driver, &formatDetails, formatEnumCallback, NULL, NULL);
-
-		delete [] (char *)waveFormat;
-
-		acmDriverClose(driver, 0);
-
-		return 1;
-	}
-
-	BOOL __stdcall Thunder::formatEnumCallback(HACMDRIVERID driverId, LPACMFORMATDETAILS formatDetails, DWORD_PTR dwInstance, DWORD fdwSupport)
-	{
-		if (formatDetails->pwfx->wFormatTag == WAVE_FORMAT_GSM610 &&
-			formatDetails->pwfx->nChannels == 1 &&
-			formatDetails->pwfx->nSamplesPerSec == SampleRate)
-		{
-			Thunder::driverId = driverId;
-		}
-		return 1;
 	}
 }


### PR DESCRIPTION
The primary motivator here is to more easily support building WaveSabre (especially the VST plugins) on platforms other than Windows by isolating the Windows-specific stuff as much as possible. Note that this patch doesn't actually isolate the Windows-specific sample loading bits entirely, as the wave format struct leaks out - but I think the best way to handle this is to do this step first, and deal with the rest once we have actual code for other platform(s) to compare to, and reconcile things then.

A secondary motivator is that this code was basically duplicated, and arguably should have been shared initially. However, we chose not to do that as Thunder is technically deprecated, so we thought we'd just leave it as-is and move on. However, there seems to be some interest in getting older songs running on other platforms and not just new stuff, so this bit of maintainence makes sense.

Size-wise, this adds 20 bytes or so compressed, which is low enough to ignore in most cases.

This supercedes #52.