### PR TITLE
Use EffectiveName instead of UserName for track names

### DIFF
--- a/WaveSabreConvert/LiveParser.cs
+++ b/WaveSabreConvert/LiveParser.cs
@@ -213,7 +213,7 @@ namespace WaveSabreConvert
                         case "Name":
                             if (track.Name == null)
                             {
-                                reader.ReadToFollowing("UserName");
+                                reader.ReadToFollowing("EffectiveName");
                                 track.Name = getValueAttrib();
                             }
                             break;


### PR DESCRIPTION
For Ableton projects, using EffectiveName instead of UserName for track names during parsing makes more sense.. UserName will override EffectiveName anyway, but this makes the default names for return tracks and Master track actually be used (where UserName is blank unless explicitly renamed)