### PR TITLE
Different type of FastSin

### DIFF
--- a/WaveSabreCore/include/WaveSabreCore/Helpers.h
+++ b/WaveSabreCore/include/WaveSabreCore/Helpers.h
@@ -96,11 +96,7 @@ namespace WaveSabreCore
 
 		static VoiceMode ParamToVoiceMode(float param);
 		static float VoiceModeToParam(VoiceMode type);
-	private:
-		static const int fastSinTabLog2Size = 9; // size = 512
-		static const int fastSinTabSize = (1 << fastSinTabLog2Size);
-		static const int adjustedFastSinTabSize = fastSinTabSize + 1;
-		static double fastSinTab[adjustedFastSinTabSize];
+
 	};
 }
 

--- a/WaveSabreCore/src/Helpers.cpp
+++ b/WaveSabreCore/src/Helpers.cpp
@@ -63,24 +63,6 @@ static __declspec(naked) float __vectorcall fpuExp2F(float x)
 		ret
 	}
 }
-
-static __declspec(naked) double __vectorcall fpuSin(double x)
-{
-	__asm
-	{
-		sub esp, 8
-
-		movsd mmword ptr [esp], xmm0
-		fld qword ptr [esp]
-		fsin
-		fstp qword ptr [esp]
-		movsd xmm0, mmword ptr [esp]
-
-		add esp, 8
-
-		ret
-	}
-}
 #endif // defined(_MSC_VER) && defined(_M_IX86)
 
 namespace WaveSabreCore
@@ -89,21 +71,9 @@ namespace WaveSabreCore
 	int Helpers::CurrentTempo = 120;
 	int Helpers::RandomSeed = 1;
 
-	double Helpers::fastSinTab[adjustedFastSinTabSize];
-
 	void Helpers::Init()
 	{
 		RandomSeed = 1;
-
-		for (int i = 0; i < adjustedFastSinTabSize; i++)
-		{
-			double phase = double(i) * ((M_PI * 2) / fastSinTabSize);
-#if defined(_MSC_VER) && defined(_M_IX86)
-			fastSinTab[i] = fpuSin(phase);
-#else
-			fastSinTab[i] = sin(phase);
-#endif
-		}
 	}
 
 	float Helpers::RandFloat()
@@ -136,27 +106,14 @@ namespace WaveSabreCore
 
 	double Helpers::FastSin(double x)
 	{
-		// normalize range from 0..2PI to 1..2
-		const auto phaseScale = 1.0 / (M_PI * 2);
-		x *= phaseScale;
-		auto phase = x - floor(x) + 1.0;
-
-		// the exponent is always 0 now, which allows us to use the significand bits directly
-		auto phaseAsInt = *reinterpret_cast<unsigned long long*>(&phase);
-
-		const auto fractBits = 32 - fastSinTabLog2Size;
-		const auto fractScale = 1 << fractBits;
-		const auto fractMask = fractScale - 1;
-
-		auto significand = (unsigned int)(phaseAsInt >> (52 - 32));
-		auto index = significand >> fractBits;
-		int fract = significand & fractMask;
-
-		auto left = fastSinTab[index];
-		auto right = fastSinTab[index + 1];
-
-		auto fractMix = fract * (1.0 / fractScale);
-		return left + (right - left) * fractMix;
+		x *= 1.0 / (M_PI * 2.0); // normalize range from 0..2PI to 0..1
+		x -= floor(x + 0.25);
+		x  = 1.0 - 4.0 * fabs(x - 0.25); // triangle wave
+		double x2 = x * x;
+		return (((  -0.00422146432893904 * x2 +
+					0.07923925545277462) * x2 +
+					-0.645814117918732) * x2 +
+					1.5707963267948963) * x; // sine shaper (similar to one in NI Reaktor)
 	}
 
 	double Helpers::Square135(double phase)


### PR DESCRIPTION
Different fastSin implementation, without LUT.

Here is couple illustrations. Green is error with linear interpolation on LUT with 512 entries. Red line is error with this implementation. Both are scaled by 2048 for visibility. 
<img width="1274" height="744" alt="01" src="https://github.com/user-attachments/assets/e71784d0-852e-479b-9043-cf65c9936989" />
<img width="841" height="662" alt="02" src="https://github.com/user-attachments/assets/e5bec4ba-8f3d-44f3-840d-11cb06f7509c" />

This method has much smaller assembly size, since it doesn't require table preparation. Also it is considerably more performant:
* up to 5.5 times on SSE2
* up to 2 times on AVX2

PolySin here is the new implementation.
<img width="1012" height="837" alt="03" src="https://github.com/user-attachments/assets/8896ede4-57a1-4ac2-8ee7-caa71023f46f" />

Both basically without actual vectorization, just by virtue of pure and simple computation without retrieving stuff from memory.

Basically it generates triangle wave with sine shaper afterwards. Sine shapers idea is a simple 7-th degree polynomial. Idea of exact polynomial construction was taken from NI Reaktor Core library and recalculated with better precision.